### PR TITLE
Restore deleted docs to fix README links

### DIFF
--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -1,0 +1,94 @@
+# Integrations & accelerators
+
+Curated list of open-source projects that can accelerate Social Auto Engine. These aren't dependencies yet — they're a shortlist of "if we want X, here's the project that already solved it."
+
+Last updated: 2026-05-02
+
+## Top 3 — if we could only pick three
+
+1. **[Postiz](https://github.com/gitroomhq/postiz-app)** — direct competitor, ~22k stars. Study their provider abstraction layer end-to-end before designing ours.
+2. **[CRUDAdmin](https://github.com/benavlabs/crudadmin)** — FastAPI + HTMX admin with auth and event tracking. Drop in over our SQLite tables and ship the accounts/posts CRUD weeks earlier.
+3. **[python-statemachine](https://github.com/fgmacedo/python-statemachine)** — replaces our string status flags with a proper state machine: `draft → pending → approved → scheduled → posted → failed`. Has a literal `ApprovalWorkflow` example.
+
+---
+
+## Open-source social media schedulers
+
+| Repo | Stars | License | Why it matters | How we'd use it |
+|------|-------|---------|----------------|-----------------|
+| [gitroomhq/postiz-app](https://github.com/gitroomhq/postiz-app) | ~22k | AGPL-3.0 | Direct competitor; supports 30+ platforms with AI scheduling | Study provider abstraction & approval/team UX patterns |
+| [inovector/mixpost](https://github.com/inovector/mixpost) | ~2.1k | MIT (Lite) | Self-hosted Buffer alternative, Laravel | Mirror multi-account/workspace data model and media-library schema |
+| [growchief/growchief](https://github.com/growchief/growchief) | ~3k | AGPL-3.0 | OSS social automation focused on outreach | Workflow node system for chained "post → comment → DM" sequences |
+
+## Meta / Facebook Graph API libraries
+
+| Repo | Stars | License | Why it matters | How we'd use it |
+|------|-------|---------|----------------|-----------------|
+| [facebook/facebook-python-business-sdk](https://github.com/facebook/facebook-python-business-sdk) | ~1.2k | Custom (Meta) | Official Meta SDK, auto-generated, always current | Use directly for Ads/Insights instead of hand-rolling endpoints |
+| [sns-sdks/python-facebook](https://github.com/sns-sdks/python-facebook) | ~700 | Apache-2.0 | Maintained Graph API wrapper covering Pages, IG, Threads | Drop-in replacement for our 37 Graph tools' transport layer |
+
+## Multi-platform posting libraries
+
+| Repo | Stars | License | Why it matters | How we'd use it |
+|------|-------|---------|----------------|-----------------|
+| [subzeroid/instagrapi](https://github.com/subzeroid/instagrapi) | ~5.8k | MIT | Reverse-engineered IG private API; reaches what Graph API can't | Optional adapter for Reels/Stories the official API restricts |
+| [tweepy/tweepy](https://github.com/tweepy/tweepy) | ~11k | MIT | Battle-tested X/Twitter v2 client | Wrap as our X provider, supports media upload |
+| [davidteather/TikTok-Api](https://github.com/davidteather/TikTok-Api) | ~5.2k | MIT | Unofficial TikTok scraper for analytics/trends (not posting) | Trend monitoring and competitor watch |
+| [linkedin-developers/linkedin-api-python-client](https://github.com/linkedin-developers/linkedin-api-python-client) | ~400 | Apache-2.0 | Official LinkedIn client | Personal-profile + company-page posting |
+
+## AI content generation
+
+| Repo | Stars | License | Why it matters | How we'd use it |
+|------|-------|---------|----------------|-----------------|
+| [unclecode/crawl4ai](https://github.com/unclecode/crawl4ai) | ~50k | Apache-2.0 | LLM-friendly markdown crawler | Power "ingest URL → draft 5 hooks" feature |
+| [abilzerian/LLM-Prompt-Library](https://github.com/abilzerian/LLM-Prompt-Library) | ~1.5k | MIT | Curated, regularly updated prompt collection | Hook generator and copy templates for our 17-skill system |
+| [microsoft/prompt-engine-py](https://github.com/microsoft/prompt-engine-py) | ~1k | MIT | Structured prompt construction with persona/voice descriptors | Foundation for `BrandVoice` class that ships voice to LLM calls |
+
+## MCP server collections
+
+| Repo | Stars | License | Why it matters | How we'd use it |
+|------|-------|---------|----------------|-----------------|
+| [oliverames/meta-mcp-server](https://github.com/oliverames/meta-mcp-server) | small/active | MIT | 200+ Meta tools (Pages, IG, Threads, Ads) | Borrow tool definitions for Threads, Ad Library, Conversions API |
+| [TensorBlock/awesome-mcp-servers](https://github.com/TensorBlock/awesome-mcp-servers) | ~1.5k | MIT | [Social-media + content section](https://github.com/TensorBlock/awesome-mcp-servers/blob/main/docs/social-media--content-platforms.md) | Index for finding Reddit/YouTube/LinkedIn MCPs to add |
+| [modelcontextprotocol/servers](https://github.com/modelcontextprotocol/servers) | ~70k | MIT | Reference servers + best-practice patterns | Borrow auth, transport, and tool-registration patterns |
+
+## HTMX / FastAPI admin & dashboards
+
+| Repo | Stars | License | Why it matters | How we'd use it |
+|------|-------|---------|----------------|-----------------|
+| [benavlabs/crudadmin](https://github.com/benavlabs/crudadmin) | ~700 | MIT | FastAPI + HTMX admin with auth and event tracking | Drop-in admin for users/accounts/posts CRUD |
+| [jowilf/starlette-admin](https://github.com/jowilf/starlette-admin) | ~1.7k | MIT | File-field, multi-DB, rich filtering | Media library management UI |
+| [aminalaee/sqladmin](https://github.com/aminalaee/sqladmin) | ~2.7k | BSD-3 | Lightweight SQLAlchemy admin | Quickest zero-config CRUD over our tables |
+| [volfpeter/fastapi-htmx-tailwind-example](https://github.com/volfpeter/fastapi-htmx-tailwind-example) | ~300 | MIT | SSE streaming, dialogs, lazy tables | Live approval-queue updates without JS framework |
+
+## Apify alternatives (self-hosted scraping)
+
+| Repo | Stars | License | Why it matters | How we'd use it |
+|------|-------|---------|----------------|-----------------|
+| [apify/crawlee-python](https://github.com/apify/crawlee-python) | ~7k | Apache-2.0 | Apify's OSS framework — Playwright + proxy rotation | Self-hosted competitor/audience scraping, replaces SaaS calls |
+| [scrapy/scrapy](https://github.com/scrapy/scrapy) | ~55k | BSD-3 | Reference Python crawler | High-volume scheduled scrapes (top posts, hashtag trends) |
+
+## Approval queue / workflow
+
+| Repo | Stars | License | Why it matters | How we'd use it |
+|------|-------|---------|----------------|-----------------|
+| [fgmacedo/python-statemachine](https://github.com/fgmacedo/python-statemachine) | ~1.8k | MIT | Has explicit `ApprovalWorkflow` example | Model post lifecycle: `draft → pending → approved → scheduled → posted → failed` |
+| [PrefectHQ/prefect](https://github.com/PrefectHQ/prefect) | ~19k | Apache-2.0 | Workflow orchestrator with retries, scheduling, observability | Replace cron + ad-hoc retries for post execution |
+
+## Awesome lists
+
+| Repo | Stars | License | Why it matters |
+|------|-------|---------|----------------|
+| [mjhea0/awesome-fastapi](https://github.com/mjhea0/awesome-fastapi) | ~10k | CC0 | Source of FastAPI extensions (auth, rate-limit, events) we'll need |
+
+---
+
+## Recommended integration order (next 3 PRs)
+
+1. **`python-facebook`** — replaces our hand-rolled Graph API code in `facebook_api.py`. Smaller surface area, less to maintain, follows Meta's spec changes automatically. ~1 day of work.
+
+2. **`python-statemachine`** — refactor `dashboard/db.py` so post status uses a state machine instead of strings. Catches invalid transitions at compile/test time (e.g. you can't go `published → pending`). ~half a day.
+
+3. **`instagrapi` adapter** — adds Instagram publishing as a sibling to the Facebook flow. Your current Page Token already includes `instagram_content_publish` scope, so the API access is handled. ~2 days.
+
+After those three, the platform meaningfully expands without rewriting much.

--- a/docs/specs/2026-05-02-approval-queue-and-dashboard-mvp-design.md
+++ b/docs/specs/2026-05-02-approval-queue-and-dashboard-mvp-design.md
@@ -1,0 +1,405 @@
+# Spec: Approval Queue + Dashboard MVP (Slice 2)
+
+**Date:** 2026-05-02
+**Status:** Draft, awaiting user review
+
+## Background
+
+`facebook-mcp-server` exposes ~37 tools an LLM agent can call against a Facebook Page (post, reply, hide/delete comments, schedule posts, fetch insights). Today the agent acts unsupervised — anything Claude calls hits Facebook immediately. The user wants a control plane: every write/destructive call should pause for human approval before it leaves the local machine, with a UI to review and edit proposed actions.
+
+This document specifies **Slice 2** of a multi-slice plan. Slice 1 (foundation hardening) is deferred except for the minimum subset the queue depends on. Slices 3+ (audit log, webhooks, Messenger inbox, sentiment, video/Reels, saved replies, advanced dashboard) are out of scope here.
+
+## Goals
+
+1. Every write/destructive tool call blocks until a human approves, rejects, or 30 minutes elapses.
+2. Read tools execute immediately — no queue interaction, no dashboard dependency.
+3. Each tool's policy (`auto` / `approve` / `approve_confirm`) is configurable per-tool with sensible tier-based defaults.
+4. The human can: approve as-is, approve with edits to the args, approve with a free-text note back to the agent, or reject with a reason.
+5. The dashboard process survives Claude Desktop restarts.
+6. Auto-launch the dashboard from the MCP on first need — zero manual setup beyond `pip install`.
+
+## Non-goals
+
+- Webhook receiver, Messenger inbox listing, video/Reel publishing, real sentiment, multi-Page support, FB OAuth, dashboard authentication — all later slices.
+- Notifications beyond visual cues in the dashboard tab. No sound, OS toast, Slack, email.
+- Audit log query/filter/export. The History page in v1 is a passive, paginated read-only list of recent actions.
+- Pagination, retries with backoff, full structured logging — slice 1, deferred.
+
+## Architecture
+
+Two processes on the same machine:
+
+```
+┌─────────────────────────┐    stdio/JSON-RPC     ┌──────────────┐
+│  facebook-mcp-server    │ ◄───────────────────► │ Claude Desk. │
+│  (started by Claude)    │                       └──────────────┘
+│                         │
+│  - Read tools: execute  │       HTTP long-poll
+│  - Write/Destructive:   │ ◄───────────────────┐
+│    enqueue + wait       │                     │
+└─────────────────────────┘                     │
+            ▲                                   │
+            │ auto-launch on first need         │
+            ▼                                   │
+┌───────────────────────────────────────────────┴──┐
+│  facebook-mcp-dashboard (long-lived)             │
+│  - FastAPI on 127.0.0.1:7651                     │
+│  - Owns SQLite at ~/.facebook-mcp/state.db       │
+│  - Inbox / Settings / History UI (Jinja + HTMX)  │
+│  - Holds long-poll connections from MCP          │
+│  - **Executes approved Facebook API calls**      │
+└──────────────────────────────────────────────────┘
+            │
+            ▼
+       Facebook Graph API
+```
+
+**MCP server (`facebook-mcp-server`).** Started by Claude Desktop on stdio. Owns the agent-facing tool surface. For read tools: executes directly. For write/destructive tools: enqueues a request to the dashboard, long-polls for the decision, relays the result.
+
+**Dashboard (`facebook-mcp-dashboard`).** Long-lived FastAPI process bound to `127.0.0.1:7651`. Owns the SQLite database at `~/.facebook-mcp/state.db`. Renders the human-facing UI. Holds the long-poll connections from the MCP. **Executes the actual Facebook API call on approval** — this matters for durability: an action the human approved still completes if Claude Desktop restarts mid-wait.
+
+**Auto-launch.** On first write/destructive call, the MCP reads the dashboard's port from `~/.facebook-mcp/dashboard.port` (default `7651` if absent) and attempts to reach `127.0.0.1:<port>/health`. If unreachable, it spawns the dashboard as a detached child (using `subprocess.Popen` with platform-specific detach flags), waits up to 5s for `/health` to respond, then proceeds. A PID file at `~/.facebook-mcp/dashboard.pid` plus an exclusive file lock (`fcntl.flock` on POSIX, `msvcrt.locking` on Windows) prevents double-spawn under concurrent first-calls.
+
+**Port fallback.** If `7651` is already in use, the dashboard tries `7652`, `7653`, … up to `7700` before failing. The chosen port is written to `~/.facebook-mcp/dashboard.port` so subsequent MCP starts find it without a discovery scan.
+
+## Component layout
+
+```
+facebook_mcp/
+├── config.py              # Existing + dashboard config (port, db path)
+├── facebook_api.py        # Existing + minimum hardening (timeout, status check, immutable params)
+├── manager.py             # Existing
+├── policy.py              # NEW — tier classification, per-tool policy resolution
+├── field_hints.py         # NEW — registry: tool name → {field name → widget hints}
+├── server.py              # FastMCP entry; wraps write/destructive tools with the approval gate
+├── queue_client.py        # NEW — MCP-side: enqueue, long-poll for decision, relay result
+└── dashboard/
+    ├── app.py             # FastAPI app + auto-launcher logic
+    ├── db.py              # SQLAlchemy models + session factory
+    ├── executor.py        # NEW — runs approved actions via FacebookAPI; updates queue rows
+    ├── routes/
+    │   ├── api.py         # POST /api/enqueue, GET /api/wait/{id}, POST /api/decide/{id}
+    │   ├── inbox.py       # HTMX views for pending requests
+    │   ├── settings.py    # Per-tool policy + timeout config UI
+    │   └── history.py     # Read-only log of past actions
+    ├── templates/         # Jinja2
+    └── static/            # HTMX + CSS
+```
+
+Two console-script entry points: `facebook-mcp-server` (stdio for Claude) and `facebook-mcp-dashboard` (HTTP for humans, also auto-launched).
+
+## Tech stack
+
+- Python 3.11+
+- FastMCP (existing)
+- FastAPI + Uvicorn — dashboard HTTP server
+- Jinja2 + HTMX — server-rendered UI with reactive widgets, no SPA build
+- SQLAlchemy + SQLite — persistent queue + tool policies
+- Pydantic — internal request/response schemas
+- httpx — MCP→dashboard long-poll client (async, handles long-running connections cleanly)
+- `pyproject.toml` replacing `requirements.txt`
+
+## Data model
+
+Two SQLite tables.
+
+### `request`
+
+Records every write/destructive tool call the agent makes.
+
+| Column | Type | Notes |
+|--------|------|-------|
+| `id` | TEXT PK | UUID4 |
+| `tool_name` | TEXT NOT NULL | e.g. `post_to_facebook` |
+| `tier` | TEXT NOT NULL | `read` / `write` / `destructive` (denormalized for filtering) |
+| `args_proposed` | TEXT NOT NULL | Agent's args as JSON |
+| `args_executed` | TEXT NULL | What the executor actually ran. Set when state ≥ `approved`; equals `args_proposed` if no edits, else the edited version. The executor only reads from this column. |
+| `state` | TEXT NOT NULL | `pending` / `approved` / `rejected` / `timed_out` / `executing` / `completed` / `failed` |
+| `decision` | TEXT NULL | `approve` / `reject` / `timeout`. "Edits" and "notes" are not separate decisions — they're optional extras on top of `approve`, derived from whether `args_executed != args_proposed` and whether `note IS NOT NULL`. |
+| `note` | TEXT NULL | Free-text from human (with `approve_with_note`) |
+| `reject_reason` | TEXT NULL | Free-text from human (with `reject`) |
+| `result` | TEXT NULL | Facebook API JSON response after execution |
+| `error` | TEXT NULL | Error envelope if execution failed |
+| `parent_request_id` | TEXT NULL | If this is a retry of a prior rejected/timed_out request |
+| `created_at` | TIMESTAMP NOT NULL | When agent enqueued |
+| `decided_at` | TIMESTAMP NULL | When human acted |
+| `executed_at` | TIMESTAMP NULL | When the FB call returned |
+
+Indexes: `(state, created_at)` for fast inbox queries, `(parent_request_id)` for retry chains, `(decided_at DESC)` for History.
+
+### `tool_policy`
+
+| Column | Type | Notes |
+|--------|------|-------|
+| `tool_name` | TEXT PK | |
+| `policy` | TEXT NOT NULL | `auto` / `approve` / `approve_confirm` |
+| `timeout_seconds` | INTEGER NULL | NULL = use default (1800 = 30 min) |
+| `updated_at` | TIMESTAMP | |
+
+Bootstrapped from tier defaults on first run. Editable from Settings page; changes apply on the next call (no MCP restart).
+
+## Request lifecycle
+
+```
+[agent calls tool]
+        │
+        ▼
+   ┌─────────┐
+   │ pending │──── timeout (30 min default) ────► [timed_out]
+   └─────────┘
+        │
+        │ human clicks Approve / Approve+Edits / Approve+Note
+        ▼
+   ┌──────────┐
+   │ approved │
+   └──────────┘
+        │
+        │ dashboard executor picks it up
+        ▼
+   ┌───────────┐
+   │ executing │
+   └───────────┘
+        │
+        │ Facebook call returns
+        ▼
+   ┌────────────────────┐
+   │ completed / failed │
+   └────────────────────┘
+
+   pending ──── human clicks Reject ────► [rejected]
+```
+
+**Happy path with sync wait:**
+
+1. Agent calls `post_to_facebook(message="...")` via MCP.
+2. MCP looks up the tool's policy. If `auto`, executes directly and returns the FB result.
+3. Otherwise, MCP `POST /api/enqueue` with `{tool_name, args_proposed, tier}`. Dashboard inserts a row in state `pending`, returns `{request_id}`.
+4. MCP issues `GET /api/wait/{request_id}?max_seconds=1800` — a long-poll that holds the connection.
+5. Dashboard renders the new row in the Inbox; human approves with optional edits/note.
+6. Dashboard updates the row to `approved` (with `args_executed` if edited), unblocks the long-poll handler.
+7. Dashboard's executor moves the row to `executing`, calls `FacebookAPI.<tool>(...)` with `args_executed`, records the result (or error) in `completed` or `failed` state.
+8. Long-poll response returns to MCP with the final result + decision metadata.
+9. MCP returns the appropriate response shape (below) to the agent.
+
+**Reject path:** dashboard moves row to `rejected`, long-poll returns immediately, no FB call is made.
+
+**Timeout path:** if no decision after `timeout_seconds`, dashboard moves row to `timed_out` and returns. The row stays visible in the Inbox marked "expired" so the human can still see what was missed.
+
+**Claude Desktop restart mid-wait:** MCP's long-poll drops. Dashboard detects connection drop but does NOT cancel the request — the human's decision still gets recorded and the action still executes when approved (durability win). The agent's conversation is gone, so the response is never delivered to Claude — but the side effect happens. The orphaned row's result is recorded in `completed` and visible in History.
+
+## Response shapes the agent receives
+
+Three top-level shapes, keyed on `status`. The `approved` shape carries optional `edited` / `note` / `execution_error` fields so any combination (as-is / edited / with note / execution failed) collapses cleanly into one structure.
+
+```json
+// 1. Approved (covers as-is, edited, with-note, and any combination)
+{
+  "status": "approved",
+  "request_id": "...",
+  "edited": false,                    // true iff args_executed != args_proposed
+  "args_executed": { "...": "..." },  // always present; equals proposed if not edited
+  "diff": null,                       // present and non-null only when edited
+  "note": null,                       // present and non-null only when human added one
+  "result": { "<fb response>": "..." },
+  "execution_error": null             // present and non-null if FB call failed after approval
+}
+
+// 2. Rejected
+{
+  "status": "rejected",
+  "request_id": "...",
+  "reason": "tone too casual for this audience"
+}
+
+// 3. Timed out
+{
+  "status": "timed_out",
+  "request_id": "...",
+  "elapsed_seconds": 1800
+}
+```
+
+The agent treats `rejected`, `timed_out`, and `approved` with non-null `execution_error` as recoverable — it can retry with adjusted args; the new request gets a fresh `request_id` with `parent_request_id` set to the prior id.
+
+## Tool tiering and policy resolution
+
+### Tier classification
+
+Tools are classified by side-effect severity:
+
+| Tier | Tools | Default policy |
+|------|-------|----------------|
+| **read** | All `get_*` tools (page posts, comments, insights, page info, fan count, share count, scheduled posts, comment replies, post permalink, top commenters, reactions breakdown, number of comments, number of likes) — and the pure-compute `filter_negative_comments` (no FB call) | `auto` |
+| **write** | `post_to_facebook`, `post_image_to_facebook`, `reply_to_comment`, `update_post`, `schedule_post`, `send_dm_to_user`, `hide_comment`, `unhide_comment`, `bulk_hide_comments`, `bulk_unhide_comments` | `approve` |
+| **destructive** | `delete_post`, `delete_comment`, `delete_comment_from_post`, `bulk_delete_comments` | `approve_confirm` |
+
+Tier is set declaratively on each tool via a one-line decorator: `@policy.tool(tier="write")`. New tools must explicitly tag their tier; an untagged tool defaults to `approve` (fail-safe).
+
+### Policy resolution
+
+For each tool call:
+
+1. Read `tool_policy` row by `tool_name`. If absent, fall back to tier default.
+2. If `policy = auto`: execute directly.
+3. If `policy = approve`: enqueue, normal approval flow.
+4. If `policy = approve_confirm`: enqueue, dashboard renders the inbox card with destructive-action treatment (red header, second confirm-click required to approve).
+
+The Settings page lets the human override any tool's policy and timeout. Changes take effect on the next call.
+
+## Edit UX — introspection-driven forms with per-field hints
+
+When the human picks **Approve with edits**, the dashboard renders a form built by introspecting the tool's signature:
+
+- `str` → `<input type="text">` (or `<textarea>` per hint)
+- `int` → `<input type="number">` (or `<input type="datetime-local">` per hint for unix-timestamp fields)
+- `list[str]` → tag chip multi-input
+- `dict[str, Any]` → JSON textarea (rare; only `filter_negative_comments`)
+
+### Field hint registry
+
+Hints live in a registry keyed by `(tool_name, field_name)`, populated at import time:
+
+```python
+# field_hints.py
+from .field_hints import register_hint
+
+register_hint("post_to_facebook", "message", widget="textarea", rows=4)
+register_hint("post_image_to_facebook", "image_url", widget="image_preview")
+register_hint("post_image_to_facebook", "caption", widget="textarea", rows=3)
+register_hint("schedule_post", "publish_time",
+              widget="datetime",
+              note="Facebook requires 10 min < publish_time < 6 months")
+register_hint("send_dm_to_user", "message", widget="textarea")
+register_hint("update_post", "new_message", widget="textarea")
+```
+
+Registry pattern (not decorator stacking) is chosen so hint coupling with `@mcp.tool()` ordering doesn't matter. The form generator queries `field_hints.get(tool_name, field_name)` and falls back to type-hint-based widget selection if no hint exists.
+
+## Dashboard surfaces
+
+### Inbox (`/`)
+
+Real-time list of pending requests. Each card:
+
+- Tool name + tier badge (write / destructive)
+- Time pending + countdown to timeout
+- Proposed args rendered as a labeled key-value table
+- Action buttons: **Approve** | **Approve & Edit** | **Approve & Note** | **Reject**
+
+Approve fires immediately. Approve & Edit opens an inline form (introspection-driven, with hints applied). Approve & Note opens a textarea. Reject opens a textarea for a reason.
+
+For `approve_confirm` tier (destructive), Approve requires a second confirm click ("Are you sure?" overlay).
+
+Live updates via HTMX SSE on `/sse/inbox`: new pending rows appear immediately, decided rows fade out. No manual refresh.
+
+Visual-only: no sound, no OS notification (per slice scope decision).
+
+### Settings (`/settings`)
+
+Per-tool grid:
+
+| Tool | Tier | Policy | Timeout |
+|------|------|--------|---------|
+| post_to_facebook | write | `approve` ▼ | `1800s` |
+| delete_post | destructive | `approve_confirm` ▼ | `1800s` |
+| ... | | | |
+
+Policy is a dropdown (`auto` / `approve` / `approve_confirm`). Timeout is a number input in seconds (with a "default" toggle to use the global 1800s). Changes save via HTMX PATCH; no save button.
+
+### History (`/history`)
+
+Read-only paginated list of past requests, newest first. Each row: tool name, tier, decision, time decided, executed-or-not, result summary. Click a row to expand: full proposed args, executed args, diff, note, error if any.
+
+Filter by decision type (approved / rejected / timed_out / failed) via URL query params; no fancy search in v1.
+
+## Foundation hardening (minimum required for slice 2)
+
+The queue depends on Facebook API calls returning structured results so the dashboard executor can record success/failure correctly. Three minimal fixes go in `facebook_api.py`:
+
+1. **Add `timeout=30` to every `requests.request` call.** Without this, a stalled FB connection hangs the dashboard executor indefinitely.
+2. **Check HTTP status before parsing JSON.** On 4xx/5xx, return a structured error envelope (`{"error": {"http_status": ..., "graph_error": ...}}`) instead of raw `response.json()`.
+3. **Stop mutating caller's `params` dict** for token injection — build a new dict locally.
+
+The rest of slice 1 (pagination, retries with backoff, full structured logging) stays deferred.
+
+## Error handling and edge cases
+
+### Dashboard not reachable when MCP wants to enqueue
+- MCP's auto-launch logic kicks in. If launch succeeds, retry enqueue.
+- If launch fails after exhausting the port-fallback range or the binary is missing, MCP returns `{"status": "error", "reason": "dashboard_unreachable", ...}` to the agent.
+
+### Dashboard crashes mid-wait
+- MCP's `httpx` long-poll raises `ReadError` / `RemoteProtocolError`.
+- MCP retries the long-poll up to 3 times with exponential backoff (1s, 2s, 4s).
+- If the dashboard auto-restarts, the request row in SQLite is still there; the long-poll resumes against the same `request_id`.
+- If retries exhaust, MCP returns `{"status": "error", "reason": "dashboard_crashed", ...}`.
+
+### MCP crashes mid-wait
+- Long-poll connection drops on the dashboard side.
+- Request row stays in `pending`. Human can still approve from the Inbox.
+- If approved, dashboard executor still runs the FB call (durability).
+- The agent that asked is gone; result is recorded but never delivered.
+
+### Two concurrent first-calls race to auto-launch
+- PID file at `~/.facebook-mcp/dashboard.pid` with an exclusive file lock (`fcntl.flock` on POSIX, `msvcrt.locking` on Windows).
+- Whichever MCP instance acquires the lock first spawns the dashboard. The other waits up to 5s for `/health` and proceeds.
+
+### Facebook API call fails after approval
+- Dashboard executor records `state=failed`, `error=<envelope>` on the row.
+- Long-poll returns the approved-but-execution-failed shape (above).
+- Agent can decide to retry — creates a new row with `parent_request_id`.
+
+### Edits change the tool's invariants
+- Example: human edits `publish_time` to be 1 minute from now, but Facebook requires ≥10 min.
+- Dashboard does not pre-validate (validation rules are FB-specific and brittle to changes).
+- The FB call returns an error; the row goes `failed`; agent sees the error envelope.
+- Future slice can add per-tool client-side validation hints.
+
+### Agent retries a previously rejected/timed_out request
+- New row, new `request_id`, `parent_request_id` set.
+- Dashboard inbox shows a "(retry of X)" badge.
+
+## Testing strategy
+
+### Unit
+- `policy.resolve(tool_name)` returns correct policy under various override combinations.
+- Field hint registry lookups.
+- `FacebookAPI` error envelope generation under HTTP failures (mocked via `responses`).
+- Tier classification: every tool in `server.py` has a tier tagged.
+
+### Integration (in-memory SQLite, mocked Facebook API)
+- Full request lifecycle: agent enqueues → dashboard renders → human approves → executor runs → result returns to agent.
+- Reject path: no FB call is made.
+- Timeout path: row marked `timed_out`, no FB call.
+- Approve-with-edits: `args_executed` differs from `args_proposed`; FB call uses edits.
+- Concurrent enqueue/decide: row state transitions are atomic.
+- Retry creates new row with `parent_request_id`.
+
+### End-to-end (real SQLite + real local dashboard, mocked FB API)
+- Auto-launch from clean state, request flows end to end.
+- MCP restart with pending row: row remains, human can still decide, FB call still happens.
+- Dashboard restart with active long-poll: MCP retry succeeds, request flows end to end.
+
+CI runs unit + integration on every PR; e2e on a manual workflow trigger.
+
+## Risks and known issues
+
+### Risks accepted by the user
+- **30-min sync wait + visual-only notification combo.** If the human steps away from the dashboard tab, the agent hangs for up to 30 minutes per write call. Mitigation: `timed_out` response is well-defined; the agent recovers gracefully. The human can lower per-tool timeouts in Settings if they find this painful.
+- **Slice scope is ~5–8× current repo size.** Implementation will likely take longer than a typical slice; expect to land it incrementally on a long-lived branch.
+
+### Implementation risks to validate during build
+- **Cross-platform detached subprocess** is fiddlier than the design implies. If implementation reveals significant trouble, fall back to requiring the user to run `facebook-mcp-dashboard` manually, and add auto-launch in a polish slice.
+- **Long-running tool calls and Claude Desktop.** A 30-min tool call has not been verified against Claude Desktop's transport / model behavior. If issues surface, the per-tool timeout knob lets the user dial down without architecture changes.
+- **HTMX SSE on a long-lived dashboard process** with many reconnects — generally fine but warrants a soak test.
+
+## Deferred work / future slices
+
+- **Slice 1 remainder:** pagination across listing tools, retry/backoff for transient FB 5xx, full structured logging, `pyproject.toml` polish.
+- **Slice 3 — Audit log:** queryable history, filter/search, export to CSV/JSON, retention policy.
+- **Slice 4 — Webhooks:** subscribe to FB page events; new comments/messages/mentions enqueue agent reflection prompts.
+- **Slice 5 — Messenger inbox:** list conversations, thread view in dashboard.
+- **Slice 6 — Real sentiment:** swap keyword filter for an LLM/model-based scorer; use it to triage the Inbox.
+- **Slice 7 — Video / Reels publishing.**
+- **Slice 8 — Saved-reply templates and moderation rules engine.**
+- **Slice 9 — Advanced dashboard:** multi-Page support, Facebook OAuth, agent activity timeline, composer view.

--- a/docs/specs/2026-05-02-multi-channel-platform-master-plan.md
+++ b/docs/specs/2026-05-02-multi-channel-platform-master-plan.md
@@ -1,0 +1,1032 @@
+# Multi-Channel Social Media Platform: Master Plan
+
+**Date:** 2026-05-02
+**Status:** Draft (v2, gaps addressed)
+**Scope:** Integration architecture for Facebook, Instagram, LinkedIn, TikTok, and X into a single dashboard with AI content generation, approval workflows, and automation at scale (1 to 100 pages/profiles).
+
+---
+
+## 1. Executive summary
+
+Merge `facebook-mcp-server` (Facebook Graph API tooling, approval queue design) and `social-media-skills` (voice system, content generation, scoring, research) into one platform. The platform publishes to five channels from a single dashboard, generates content with multiple AI providers, and gates every action behind a human approval queue that scales to 100 managed pages.
+
+The existing Slice 2 approval-queue spec (`2026-05-02-approval-queue-and-dashboard-mvp-design.md`) becomes one component inside this broader architecture. This document is Slice 0: the integration master plan that everything else fits inside.
+
+### Scope note: "1 to 100 pages"
+
+The platform manages 1 to 100 pages or profiles that already exist on each platform. These pages may be brand new (created today, zero posts, empty bio) and need to be fully built out from scratch. The platform handles everything after the page exists: populating the profile (via profile-optimizer skill), filling the feed with content, building an audience through consistent posting, and scaling that process across all connected accounts.
+
+What the platform does not do is create the page or account itself. Platform APIs do not support programmatic page/account creation. The user creates the page on Facebook, Instagram, LinkedIn, X, or TikTok, then connects it to the dashboard. From that point, the platform takes over: generating content, scheduling posts, filling empty feeds, and scaling that workflow from 1 account to 100.
+
+---
+
+## 2. Platform API reality
+
+Each platform has different API access requirements. The plan must be honest about what is available today, what requires application review, and what costs money.
+
+### 2.1 Facebook (ready now)
+
+- **API:** Graph API v22.0
+- **Access:** Page Access Token via Facebook Developer App
+- **Capabilities:** Post text/image/video, schedule posts, read insights, manage comments, send DMs, bulk operations
+- **Limits:** 200 calls per user per hour (standard), 4800 per hour (approved app)
+- **Cost:** Free
+- **Current state:** Fully implemented in `facebook-mcp-server`
+
+### 2.2 Instagram (ready now, via Facebook)
+
+- **API:** Instagram Graph API (subset of Facebook Graph API)
+- **Access:** Facebook Page linked to Instagram Professional Account, same app
+- **Capabilities:** Publish photos/carousels/reels, read insights, manage comments, read mentions
+- **Limits:** 25 content publishing API calls per 24 hours per account. This is the hardest constraint in the system.
+- **Cannot do via API:** Stories (only via Content Publishing API for business accounts with approval), DMs (only via Messenger Platform for approved apps), live video
+- **Cost:** Free
+- **Gap:** Reels publishing requires video hosted at a public URL. The platform needs an upload-then-publish pipeline.
+
+### 2.3 LinkedIn (requires app review)
+
+- **API:** LinkedIn Marketing Developer Platform (v2 REST, transitioning to versioned API)
+- **Access:** OAuth 2.0 three-legged flow. Posting to org pages requires `w_organization_social` scope, which needs Marketing Developer Platform approval (takes 2 to 8 weeks).
+- **Capabilities:** Post text/image/video/articles/polls, read analytics, comment management
+- **Limits:** 100 API calls per user per day for content creation. 1000 per day for reading.
+- **Cannot do via API:** Carousel posts (only native), newsletter publishing, live video
+- **Cost:** Free for approved apps
+- **Gap:** App review is a blocking dependency. Plan for a manual posting fallback during the review period.
+
+### 2.4 X / Twitter (costs money)
+
+- **API:** X API v2
+- **Access:** OAuth 2.0 or OAuth 1.0a. Basic tier is free but read-only (no posting).
+- **Capabilities (Pro tier):** Post tweets/threads/polls, upload media, read timeline, manage lists
+- **Limits:** Pro tier: 100 posts per 15 minutes, 300k tweet reads per month
+- **Cost:** Pro tier is $200/month per app. This is non-negotiable for write access.
+- **Cannot do via API:** Spaces (hosting), Communities posting, X Premium features
+- **Gap:** The $200/month cost must be acknowledged to the user before enabling X integration. Do not silently assume this cost.
+
+### 2.5 TikTok (requires app review)
+
+- **API:** TikTok Content Posting API
+- **Access:** OAuth 2.0. Requires app registration and review by TikTok (takes 2 to 6 weeks). The "Direct Post" scope requires additional review.
+- **Capabilities:** Upload and publish videos (Direct Post or Inbox method), read video insights
+- **Limits:** Varies by app approval level. Inbox method: users must manually confirm publish in TikTok app.
+- **Cannot do via API:** Image posts (TikTok is video-only API), live streaming, duets, stitches, TikTok Shop
+- **Cost:** Free for approved apps
+- **Gap:** TikTok's "Inbox" method means the video goes to the user's TikTok drafts and they tap publish manually. "Direct Post" requires higher-level approval. The dashboard must clearly indicate which mode is active.
+
+### 2.6 Platform readiness summary
+
+| Platform  | API ready | Write access | Review needed | Monthly cost | Posting limit              |
+|-----------|-----------|--------------|---------------|--------------|----------------------------|
+| Facebook  | Yes       | Yes          | No            | Free         | 200 calls/hr               |
+| Instagram | Yes       | Yes          | No            | Free         | 25 publishes/24hr/account  |
+| LinkedIn  | Partial   | Needs review | 2-8 weeks     | Free         | 100 creates/day            |
+| X         | Yes       | Pro tier     | No            | $200/month   | 100 posts/15min            |
+| TikTok    | Partial   | Needs review | 2-6 weeks     | Free         | Varies by approval         |
+
+---
+
+## 3. Architecture
+
+### 3.1 System overview
+
+```
++-------------------------------------------------------------------+
+|                        User's browser                              |
+|                  Dashboard (FastAPI + HTMX)                        |
+|                  http://127.0.0.1:7651                             |
++-------------------------------------------------------------------+
+        |                    |                    |
+        v                    v                    v
++---------------+  +------------------+  +------------------+
+| Approval      |  | Content          |  | Analytics        |
+| Queue         |  | Generation       |  | Engine           |
+| (SQLite)      |  | (multi-AI)       |  | (per-platform)   |
++---------------+  +------------------+  +------------------+
+        |                    |                    |
+        v                    v                    v
++-------------------------------------------------------------------+
+|                    Platform Router                                  |
+|         Routes approved actions to platform adapters               |
++-------------------------------------------------------------------+
+    |          |           |          |          |
+    v          v           v          v          v
++--------+ +--------+ +--------+ +--------+ +--------+
+|Facebook| |Insta-  | |LinkedIn| |  X     | |TikTok  |
+|Graph   | |gram    | |Market- | |  API   | |Content |
+|API     | |Graph   | |ing API | |  v2    | |Post API|
++--------+ +--------+ +--------+ +--------+ +--------+
+```
+
+### 3.2 Component breakdown
+
+**Layer 1: Dashboard (FastAPI + Jinja2 + HTMX)**
+- Server-rendered pages, no SPA build step
+- HTMX for reactive updates (SSE for approval queue, polling for analytics)
+- Serves on 127.0.0.1:7651 (port fallback 7651-7700)
+- All state in SQLite, no external database dependency
+
+**Layer 2: Core services**
+
+| Service              | Responsibility                                                    |
+|----------------------|-------------------------------------------------------------------|
+| Approval Queue       | Human-in-the-loop gate for all write operations (Slice 2 spec)   |
+| Content Generator    | Multi-AI content creation (text, image, video)                   |
+| Voice Engine         | Loads voice.md + about-me.md, enforces voice consistency         |
+| Scheduler            | Cron-style scheduling with per-platform optimal time suggestions |
+| Analytics Engine     | Pulls insights from each platform, normalises into common schema |
+| Scraper              | Apify-backed research for trends, competitor analysis, outliers  |
+
+**Layer 3: Platform adapters**
+
+Each platform gets its own adapter module implementing a common interface:
+
+```python
+class PlatformAdapter:
+    async def publish_text(self, account_id: str, content: PostContent) -> PublishResult
+    async def publish_image(self, account_id: str, content: PostContent, media: MediaRef) -> PublishResult
+    async def publish_video(self, account_id: str, content: PostContent, media: MediaRef) -> PublishResult
+    async def get_insights(self, account_id: str, post_id: str) -> InsightsData
+    async def get_comments(self, account_id: str, post_id: str) -> list[Comment]
+    async def delete_post(self, account_id: str, post_id: str) -> bool
+    def get_rate_limits(self) -> RateLimitInfo
+    def get_capabilities(self) -> set[Capability]
+```
+
+The `get_capabilities()` method returns what this platform can actually do. The dashboard uses this to show/hide UI elements per platform (e.g., no "post image" button for TikTok, no "carousel" for LinkedIn via API).
+
+### 3.3 Directory structure
+
+```
+facebook-mcp-server/
+  facebook_mcp/
+    __init__.py
+    server.py                   # FastMCP entry point (existing, extended)
+    config.py                   # Env vars, platform credentials
+    models.py                   # SQLAlchemy models (request, tool_policy, account, post)
+    
+    adapters/
+      __init__.py
+      base.py                   # PlatformAdapter ABC
+      facebook.py               # Facebook Graph API (migrated from facebook_api.py)
+      instagram.py              # Instagram Graph API
+      linkedin.py               # LinkedIn Marketing API
+      x.py                      # X API v2
+      tiktok.py                 # TikTok Content Posting API
+    
+    approval/
+      __init__.py
+      queue.py                  # Approval queue (from Slice 2 spec)
+      policy.py                 # Tool tiering: read/write/destructive
+      field_hints.py            # Edit UX hints per field
+    
+    content/
+      __init__.py
+      generator.py              # Multi-AI content generation orchestrator
+      voice.py                  # Voice system loader (about-me.md, voice.md)
+      hooks.py                  # Hook generator (6 types)
+      scorer.py                 # Post scorer (5 criteria)
+      research.py               # Niche research via Apify/web
+    
+    media/
+      __init__.py
+      image_gen.py              # Image generation (DALL-E, Gemini, etc.)
+      video_gen.py              # Video generation (ElevenLabs, HeyGen, Remotion)
+      uploader.py               # Media upload to platform-required hosting
+    
+    dashboard/
+      __init__.py
+      app.py                    # FastAPI app
+      routes/
+        inbox.py                # Approval inbox (SSE)
+        compose.py              # Multi-platform compose
+        accounts.py             # Account management
+        analytics.py            # Cross-platform analytics
+        settings.py             # Tool policies, AI provider config
+        history.py              # Action history log
+      templates/
+        base.html
+        inbox.html
+        compose.html
+        accounts.html
+        analytics.html
+        settings.html
+      static/
+        styles.css
+        htmx.min.js
+    
+    scheduler/
+      __init__.py
+      cron.py                   # Scheduled post execution
+      optimal_times.py          # Per-platform best posting times
+    
+    analytics/
+      __init__.py
+      collector.py              # Pull insights from all platforms
+      normaliser.py             # Common schema for cross-platform comparison
+```
+
+### 3.4 Data model
+
+SQLite database at `~/.facebook-mcp/platform.db`.
+
+**accounts table**
+```sql
+CREATE TABLE accounts (
+    id            TEXT PRIMARY KEY,         -- uuid
+    platform      TEXT NOT NULL,            -- facebook|instagram|linkedin|x|tiktok
+    display_name  TEXT NOT NULL,
+    username      TEXT,
+    access_token  TEXT NOT NULL,            -- encrypted at rest
+    refresh_token TEXT,
+    token_expiry  TEXT,
+    page_id       TEXT,                     -- platform-specific page/profile ID
+    capabilities  TEXT,                     -- JSON array of supported actions
+    is_active     INTEGER DEFAULT 1,
+    created_at    TEXT DEFAULT CURRENT_TIMESTAMP,
+    updated_at    TEXT DEFAULT CURRENT_TIMESTAMP
+);
+```
+
+**posts table**
+```sql
+CREATE TABLE posts (
+    id              TEXT PRIMARY KEY,
+    account_id      TEXT NOT NULL REFERENCES accounts(id),
+    platform        TEXT NOT NULL,
+    content_text    TEXT,
+    media_urls      TEXT,                   -- JSON array
+    post_type       TEXT,                   -- text|image|video|carousel|reel
+    platform_post_id TEXT,                  -- ID returned by platform after publish
+    status          TEXT DEFAULT 'draft',   -- draft|queued|approved|published|failed
+    scheduled_at    TEXT,
+    published_at    TEXT,
+    approval_id     TEXT REFERENCES request(id),
+    ai_provider     TEXT,                   -- which AI generated this
+    voice_score     REAL,                   -- voice match score if scored
+    created_at      TEXT DEFAULT CURRENT_TIMESTAMP
+);
+```
+
+**request table** (from Slice 2 spec, extended)
+```sql
+CREATE TABLE request (
+    id            TEXT PRIMARY KEY,
+    tool_name     TEXT NOT NULL,
+    arguments     TEXT NOT NULL,            -- JSON
+    account_id    TEXT REFERENCES accounts(id),
+    platform      TEXT,
+    status        TEXT DEFAULT 'pending',   -- pending|approved|rejected|timed_out|executing|completed|failed
+    result        TEXT,                     -- JSON
+    edits         TEXT,                     -- JSON: fields the user modified
+    notes         TEXT,
+    created_at    TEXT DEFAULT CURRENT_TIMESTAMP,
+    decided_at    TEXT,
+    completed_at  TEXT
+);
+```
+
+---
+
+## 4. Dashboard UI design
+
+### 4.1 Layout
+
+```
++------------------------------------------------------------------+
+| LOGO   Inbox(3)  Compose  Accounts  Analytics  Settings   [user] |
++------------------------------------------------------------------+
+|                                                                    |
+|                     [Active page content]                          |
+|                                                                    |
++------------------------------------------------------------------+
+```
+
+Top navigation bar with badge counts. No sidebar. Mobile-responsive via CSS grid.
+
+### 4.2 Compose page (the core workflow)
+
+This is where users create and queue posts. Single page, multi-platform.
+
+```
++------------------------------------------------------------------+
+| COMPOSE                                                    [Draft]|
++------------------------------------------------------------------+
+| Platforms: [x] Facebook  [x] Instagram  [ ] LinkedIn             |
+|            [ ] X         [ ] TikTok                               |
+|                                                                    |
+| Account:   [Dropdown: select page/profile per platform]           |
+|            (shows only accounts with write capability)            |
++------------------------------------------------------------------+
+| AI Generate:                                                      |
+|  Topic: [___________________________________]                     |
+|  Provider: [Claude v] [Gemini] [OpenAI] [Custom]                 |
+|  Framework: [PAS v] [AIDA] [Story] [Contrarian] [Hook only]     |
+|  [Generate]                                                       |
++------------------------------------------------------------------+
+| Post content:                                                     |
+| +--------------------------------------------------------------+ |
+| | [Rich text editor with character count per platform]          | |
+| | Facebook: 1247/63206 chars                                    | |
+| | Instagram: 1247/2200 chars                                    | |
+| |                                                                | |
+| | Platform-specific preview tabs:                                | |
+| | [Facebook] [Instagram] [LinkedIn] [X] [TikTok]               | |
+| +--------------------------------------------------------------+ |
++------------------------------------------------------------------+
+| Media:                                                            |
+|  [Upload image] [Generate image] [Upload video] [Generate video] |
+|  Provider: [DALL-E v] [Gemini] [Nano Banana]                    |
+|  (disabled buttons for platforms that don't support the format)   |
++------------------------------------------------------------------+
+| Schedule: [Now v] [Pick date/time] [Optimal time]                |
++------------------------------------------------------------------+
+| [Score post]  [Save draft]  [Submit for approval]                |
++------------------------------------------------------------------+
+```
+
+**Key behaviours:**
+- Character count updates live per platform. Warns when content exceeds a platform's limit.
+- Platform-specific preview tabs show how the post will look on each channel.
+- "Generate" calls the selected AI provider with voice.md context.
+- "Score post" runs the post-scorer skill against the user's historical data.
+- "Submit for approval" creates one approval request per selected platform. Each can be approved or rejected independently.
+- If only one platform is selected and the user has skip-approval enabled for that tool, it publishes immediately with a confirmation dialog: "This will publish immediately without approval. Are you sure?"
+
+### 4.3 Inbox page (approval queue)
+
+From the Slice 2 spec, extended for multi-platform:
+
+```
++------------------------------------------------------------------+
+| INBOX                                          [3 pending]        |
++------------------------------------------------------------------+
+| +--------------------------------------------------------------+ |
+| | [Facebook icon] Post to "Tech News Daily"                     | |
+| | "5 AI tools that changed how I work this month..."            | |
+| | Submitted 2 min ago                                           | |
+| | [Edit] [Approve] [Reject]                                     | |
+| +--------------------------------------------------------------+ |
+| | [Instagram icon] Post to @techdaily                           | |
+| | Same content, adapted for Instagram                           | |
+| | Submitted 2 min ago                                           | |
+| | [Edit] [Approve] [Reject]                                     | |
+| +--------------------------------------------------------------+ |
+| | [LinkedIn icon] Post to Tech News Company Page                | |
+| | Same content, adapted for LinkedIn                            | |
+| | Submitted 2 min ago                                           | |
+| | [Edit] [Approve] [Reject]                                     | |
+| +--------------------------------------------------------------+ |
+```
+
+Each approval card shows:
+- Platform icon and account name
+- Content preview (truncated, expandable)
+- Media thumbnails if attached
+- Edit button opens inline editor with platform-specific constraints
+- Approve/reject with optional notes
+- Bulk approve: select multiple and approve all
+
+At 100 pages, the inbox needs filtering:
+- Filter by platform
+- Filter by account
+- Filter by status
+- Sort by submitted time (default) or platform
+- "Approve all from [account]" batch action
+
+### 4.4 Accounts page
+
+```
++------------------------------------------------------------------+
+| ACCOUNTS                                       [+ Add account]   |
++------------------------------------------------------------------+
+| Platform    | Account           | Status    | Posts | Actions     |
+|-------------|-------------------|-----------|-------|-------------|
+| Facebook    | Tech News Daily   | Connected | 847   | [Manage]    |
+| Facebook    | AI Weekly         | Connected | 234   | [Manage]    |
+| Instagram   | @techdaily        | Connected | 156   | [Manage]    |
+| LinkedIn    | Tech News Co.     | Pending   | 0     | [Auth]      |
+| X           | @technews         | No plan   | 0     | [Setup]     |
+| TikTok      | @techdaily        | In review | 0     | [Status]    |
++------------------------------------------------------------------+
+```
+
+"Add account" starts the OAuth flow for the selected platform. The dashboard handles the callback and stores tokens.
+
+Status values:
+- **Connected** - API access working, ready to post
+- **Pending review** - App submitted to platform for review (LinkedIn, TikTok)
+- **Token expired** - Needs re-authentication
+- **No plan** - Platform requires paid tier (X Pro at $200/month)
+- **In review** - Application under platform review
+- **Disconnected** - User removed access
+
+### 4.5 Analytics page
+
+Cross-platform analytics with normalised metrics:
+
+```
++------------------------------------------------------------------+
+| ANALYTICS                          [Last 30 days v] [Export CSV] |
++------------------------------------------------------------------+
+| Total reach: 245,892  | Engagement: 12,847  | Posts: 47          |
++------------------------------------------------------------------+
+| [Engagement trend chart - all platforms stacked]                  |
++------------------------------------------------------------------+
+| Best performing posts:                                            |
+| 1. [FB] "5 AI tools..." - 3,421 reactions, 892 comments         |
+| 2. [IG] Carousel: "The AI stack" - 2,104 likes, 341 comments    |
+| 3. [LI] "Why I stopped..." - 1,872 reactions, 503 comments      |
++------------------------------------------------------------------+
+| Platform breakdown:                                               |
+| [Facebook chart] [Instagram chart] [LinkedIn chart] [X chart]    |
++------------------------------------------------------------------+
+```
+
+### 4.6 Settings page
+
+```
++------------------------------------------------------------------+
+| SETTINGS                                                          |
++------------------------------------------------------------------+
+| Approval policies:                                                |
+|   Post to Facebook:     [Require approval v]                     |
+|   Post to Instagram:    [Require approval v]                     |
+|   Delete any post:      [Require double confirm v]               |
+|   Read insights:        [Auto-approve v]                         |
+|                                                                    |
+| AI providers:                                                     |
+|   OpenAI API key:       [***********xyz]  [Test] [Remove]        |
+|   Gemini API key:       [***********abc]  [Test] [Remove]        |
+|   Claude API key:       [Using MCP session - no key needed]      |
+|   DALL-E:               [Via OpenAI key]                         |
+|   Nano Banana API:      [Not configured]  [Add]                  |
+|                                                                    |
+| Apify token:            [***********def]  [Test] [Remove]        |
+|                                                                    |
+| Voice system:                                                     |
+|   about-me.md:          [Loaded] [View] [Rebuild]                |
+|   voice.md:             [Loaded] [View] [Rebuild]                |
+|   newsletter-voice.md:  [Not found] [Build]                     |
+|                                                                    |
+| Default schedule:                                                 |
+|   Facebook:  [09:00 v] [13:00] [18:00] (3x daily)               |
+|   Instagram: [11:00 v] [19:00] (2x daily, within 25/day limit)  |
+|   LinkedIn:  [08:00 v] [17:00] (2x daily)                       |
++------------------------------------------------------------------+
+```
+
+---
+
+## 5. Automation workflow
+
+### 5.1 Content creation pipeline
+
+```
+Topic/idea
+    |
+    v
+[Voice engine loads about-me.md + voice.md]
+    |
+    v
+[AI provider generates draft]
+  - Claude (via MCP, free with subscription)
+  - OpenAI GPT-4o (API key, ~$0.01 per post)
+  - Gemini 2.5 Flash (API key, free tier available)
+    |
+    v
+[Platform adapter adjusts per channel]
+  - Facebook: full text, links expanded
+  - Instagram: 2200 char max, no links in caption, hashtags
+  - LinkedIn: professional tone adjustment, 3000 char max
+  - X: 280 char limit, thread if longer
+  - TikTok: script format for video, 150 char caption
+    |
+    v
+[Post scorer validates quality]
+  - Score against user's historical top performers
+  - Flag voice mismatches
+  - Suggest hook improvements with data
+    |
+    v
+[Media generation if needed]
+  - Image: DALL-E, Gemini, Nano Banana
+  - Video: ElevenLabs (voice) + HeyGen (avatar) + Remotion (motion)
+  - Graphic: HTML/CSS structured or AI infographic
+    |
+    v
+[Approval queue]
+  - One request per platform per account
+  - User reviews, edits, approves/rejects each
+  - Dashboard shows preview per platform
+    |
+    v
+[Platform router publishes]
+  - Respects rate limits per platform
+  - Retries on transient failures
+  - Records platform post ID for tracking
+    |
+    v
+[Analytics collection begins]
+  - Polls insights at 1hr, 24hr, 7d intervals
+  - Feeds back into scorer for future posts
+```
+
+### 5.2 Batch workflow (scaling to 100 pages)
+
+When managing many pages, the compose workflow changes:
+
+1. **Template mode:** Write one post, select 10 accounts. The system creates 10 platform-adapted variants.
+2. **Batch approval:** Inbox groups related posts. "Approve all 10 variants" button.
+3. **Staggered publishing:** Posts go out at different times to avoid looking automated. Configurable jitter (5 to 60 minutes between posts).
+4. **Rate limit awareness:** The scheduler checks remaining API quota before queuing. If Instagram has 3 publishes left today across 5 accounts, it queues the rest for tomorrow.
+5. **Priority accounts:** Mark high-value accounts as priority. These get published first when rate limits are tight.
+
+### 5.3 Approval system design
+
+The approval system must handle the tension between "every post requires approval" and "100 pages."
+
+**Approval tiers (per tool, per account):**
+
+| Tier                | Behaviour                                              | Use case                        |
+|---------------------|--------------------------------------------------------|---------------------------------|
+| `require_approval`  | Queued, waits for human approve/reject                 | Default for all write actions   |
+| `approve_confirm`   | Queued, requires approve + "are you sure" confirmation | Delete, bulk operations         |
+| `auto_approve`      | Executes immediately, logged in history                | Read operations, insights pulls |
+| `skip_approval`     | Executes immediately with warning banner               | Power users, trusted automation |
+
+**Skip-approval safeguards:**
+- Enabling skip_approval shows a permanent warning banner: "Approval is disabled for [tool] on [account]. Posts will publish immediately."
+- First post after enabling skip shows a one-time interstitial: "This post will publish to [platform] without review. Content: [preview]. Publish now?"
+- Skip-approval can be set per tool per account, not globally. You can skip approval for Facebook reads but still require it for Facebook posts.
+- Audit log records every skip-approval action with full content snapshot.
+
+**At scale (50+ accounts):**
+- Batch approve with content preview carousel
+- "Approve all similar" groups posts from the same template
+- Daily digest email: "You have 47 posts pending approval across 12 accounts"
+- Auto-reject after configurable timeout (default 72 hours) with notification
+- Dashboard shows approval SLA: average time from submit to decision
+
+---
+
+## 6. AI provider integration
+
+### 6.1 Provider matrix
+
+| Provider       | Capability        | Cost model          | Best for                          |
+|----------------|-------------------|---------------------|-----------------------------------|
+| Claude (MCP)   | Text generation   | Included with sub   | Voice-matched posts, long form    |
+| OpenAI GPT-4o  | Text generation   | ~$0.01/post         | Bulk generation, threads          |
+| Gemini 2.5     | Text + video      | Free tier + paid    | Video analysis, image gen         |
+| DALL-E 3       | Image generation  | $0.04-0.12/image    | Post graphics, thumbnails         |
+| Nano Banana*   | Image generation  | Per-image pricing   | Alternative image styles          |
+| ElevenLabs     | Voice synthesis   | Per-character        | Reel voiceovers                   |
+| HeyGen         | Avatar video      | Subscription        | Talking head videos               |
+
+### 6.2 Provider selection logic
+
+```python
+def select_provider(task: str, user_preference: str = None) -> str:
+    if user_preference:
+        return user_preference
+    
+    # Default routing
+    if task == "text_generation":
+        return "claude"           # Best voice matching via MCP context
+    elif task == "image_generation":
+        return "dall-e"           # Most reliable for structured prompts
+    elif task == "video_analysis":
+        return "gemini-2.5-flash" # Native video understanding
+    elif task == "voice_synthesis":
+        return "elevenlabs"       # Highest quality TTS
+    elif task == "infographic":
+        return "gemini"           # Best for whiteboard/branded styles
+```
+
+The user can override this per-post via the compose page dropdown.
+
+### 6.3 Voice system integration
+
+Every AI text generation call includes voice context:
+
+1. Load `about-me.md` (who, audience, topics, POV, brand promise, off-limits)
+2. Load `voice.md` (tone, rhythm, hooks, signature phrases, absence signals)
+3. Load `newsletter-voice.md` if the content originates from newsletter repurposing
+4. Inject as system context for the AI provider
+5. Post-generation: run scorer to verify voice match before queuing
+
+Claude has a natural advantage here because the voice files are already in the MCP project context. For OpenAI/Gemini, the voice content is injected into the system prompt.
+
+---
+
+## 7. Per-platform post examples
+
+### 7.1 Facebook post
+
+```
+Input topic: "5 AI tools I replaced my marketing team with"
+
+Generated post:
+-----------------------------------------------
+Last month I cancelled three software subscriptions
+and replaced them with AI tools that cost $47/month total.
+
+Here is what changed:
+
+1. Content calendar: ChatGPT + a custom prompt
+   replaced a $200/month planning tool
+2. Social graphics: Gemini image generation
+   replaced a $50/month design subscription
+3. Email sequences: Claude projects
+   replaced a copywriter retainer
+4. Analytics reports: Custom GPT
+   replaced manual spreadsheet work
+5. Video captions: Whisper API
+   replaced a transcription service
+
+Total before: $1,240/month
+Total after: $47/month
+
+The tools are not the point.
+The point is knowing which tasks
+AI actually does better than humans.
+
+What would you replace first?
+-----------------------------------------------
+Platform: Facebook
+Format: Text post
+Character count: 612/63,206
+Hashtags: None (Facebook penalises hashtag-heavy posts)
+Media: Optional HTML/CSS infographic with the cost comparison
+```
+
+### 7.2 Instagram post
+
+```
+Adapted from same topic:
+-----------------------------------------------
+I replaced 5 marketing tools with AI.
+
+Monthly cost went from $1,240 to $47.
+
+Here is the swap list:
+
+1. Content calendar: ChatGPT custom prompt
+2. Social graphics: Gemini
+3. Email sequences: Claude
+4. Analytics: Custom GPT
+5. Video captions: Whisper
+
+The tools change every month.
+The skill of knowing what to automate does not.
+
+Save this for when you are ready to cut costs.
+
+#AItools #marketingautomation #contentcreation
+-----------------------------------------------
+Platform: Instagram
+Format: Carousel (each tool = 1 slide) or single image
+Character count: 418/2,200
+Hashtags: 3-5 relevant tags (Instagram algorithm favours fewer, targeted hashtags)
+Media: Branded infographic or carousel slides
+CTA: "Save this" (Instagram's algorithm rewards saves)
+```
+
+### 7.3 LinkedIn post
+
+```
+Adapted from same topic:
+-----------------------------------------------
+I cut $1,193/month from my marketing stack last month.
+
+Not by finding cheaper tools.
+By replacing them with AI that costs $47/month total.
+
+The 5 swaps:
+
+Content calendar: $200/month tool replaced with ChatGPT + a structured prompt
+Social graphics: $50/month design sub replaced with Gemini image generation
+Email copy: Copywriter retainer replaced with Claude projects
+Analytics: Manual spreadsheets replaced with a Custom GPT
+Video captions: Transcription service replaced with Whisper API
+
+Here is what surprised me:
+
+The AI versions are not just cheaper.
+Three of them produce better output than what I was paying for.
+
+The other two are 80% as good at 5% of the cost.
+
+Knowing which is which is the actual skill.
+
+What is the first tool you would swap?
+-----------------------------------------------
+Platform: LinkedIn
+Format: Text post
+Character count: 682/3,000
+Hashtags: None (LinkedIn organic reach drops with hashtags in 2026)
+Media: Optional
+CTA: Question to drive comments
+```
+
+### 7.4 X post
+
+```
+Adapted from same topic:
+-----------------------------------------------
+Replaced 5 marketing tools with AI.
+
+$1,240/month -> $47/month
+
+The surprising part: 3 of the AI versions
+produce better output than what I was paying humans for.
+
+Thread with the full swap list:
+-----------------------------------------------
+Platform: X
+Format: Tweet (thread opener)
+Character count: 201/280
+Thread: 5 follow-up tweets, one per tool swap
+Media: None for opener, screenshot per thread tweet
+```
+
+### 7.5 TikTok script
+
+```
+Adapted from same topic:
+-----------------------------------------------
+# Reel: 5 AI Tools That Replaced My Marketing Team
+
+## Duration target
+30-35 seconds
+
+## Hook (0-3s)
+"This $47 AI stack replaced $1,240 in marketing tools."
+
+## Point 1 (3-18s)
+"The first three swaps actually produce better work.
+ChatGPT replaced my content calendar.
+Gemini replaced my design subscription.
+Claude replaced my email copywriter.
+All three, better output, fraction of the cost."
+
+## Point 2 (18-28s)
+"The other two are 80% as good at 5% of the price.
+That is the real skill here.
+Knowing which tasks AI does better
+and which ones just need to be cheaper."
+
+## CTA (28-35s)
+"Comment STACK and I will send you the full swap list
+with the exact prompts I use."
+
+## Comment trigger
+STACK
+-----------------------------------------------
+Platform: TikTok
+Format: Video (talking head or screen recording)
+Duration: 30-35 seconds
+Caption: Mirror of script, 150 chars max for preview
+```
+
+---
+
+## 8. Advertising and ad creation
+
+Ad creation was part of the original requirements. This section documents what the platform APIs offer and what this platform will support.
+
+### 8.1 Platform advertising APIs
+
+| Platform  | Ads API                          | Access requirements                        | Capabilities via API                                        |
+|-----------|----------------------------------|--------------------------------------------|-------------------------------------------------------------|
+| Facebook  | Meta Marketing API               | Marketing API access via Business Manager   | Create/manage campaigns, ad sets, ads. Audience targeting. Budget management. Performance reporting. |
+| Instagram | Meta Marketing API (same as FB)  | Same access as Facebook                    | Same as Facebook, scoped to Instagram placements             |
+| LinkedIn  | LinkedIn Ads API                 | Marketing Developer Platform approval       | Sponsored Content, Message Ads, campaign management, reporting |
+| X         | X Ads API                        | Separate from content API, requires approval| Promoted tweets, campaign management, audience targeting     |
+| TikTok    | TikTok Marketing API             | Separate app review, TikTok Business Center | Campaign creation, ad management, audience tools, reporting  |
+
+### 8.2 What this platform will support (v1)
+
+Ad creation is deferred to Phase 6 with limited scope:
+
+- **"Boost top performer" workflow:** One-click promotion of an organic post that exceeded engagement thresholds. Uses Meta Marketing API for Facebook/Instagram. This is the simplest ads integration and delivers the most value.
+- **Budget guardrails:** Hard spending cap per boost, configurable in settings. Default $50. Approval queue applies to all ad spend.
+- **Performance dashboard:** Pull ad performance metrics into the analytics page alongside organic metrics.
+
+### 8.3 What is explicitly out of scope for v1
+
+- Full campaign builders for any platform (use each platform's native ads manager instead)
+- Audience creation and lookalike targeting
+- A/B testing ad creative
+- Cross-platform ad budget optimisation
+- LinkedIn, X, and TikTok ad creation (only Meta boosting in v1)
+
+Full multi-platform ad management is a separate product. This platform focuses on organic content publishing with a "boost what works" shortcut for Meta platforms. Expanding ads support to other platforms would be a Phase 7+ initiative after the core content system is stable.
+
+---
+
+## 9. Skill-to-component mapping
+
+The `social-media-skills` project already implements most of the content pipeline. This table maps each existing skill to where it fits in the platform architecture, avoiding redundant development.
+
+| Skill               | Platform component          | Integration approach                                                        |
+|----------------------|-----------------------------|-----------------------------------------------------------------------------|
+| voice-builder        | content/voice.py            | Core dependency. Produces about-me.md + voice.md that every generation call loads. |
+| newsletter-voice     | content/voice.py            | Extension of voice engine. Loaded when repurposing newsletter content.      |
+| post-writer          | content/generator.py        | 4 frameworks (PAS, How-to, Story, Contrarian) become selectable in compose page. |
+| post-formatter       | content/generator.py        | Additional frameworks (AIDA, BAB, STAR, SLAY) added to compose dropdown.   |
+| hook-generator       | content/hooks.py            | Standalone module. Called from compose page "Generate hooks" button.        |
+| post-scorer          | content/scorer.py           | Standalone module. Called from compose page "Score post" button.            |
+| graphic-designer     | media/image_gen.py          | HTML/CSS path runs server-side. AI prompt path feeds into image gen.        |
+| gemini-infographic   | media/image_gen.py          | Whiteboard prompt template. Selectable in compose media section.           |
+| gemini-carousel      | media/image_gen.py          | Carousel generator with approval gate. Maps to Instagram carousel format.  |
+| quote-post           | media/image_gen.py          | Quote + image pipeline. Option in compose for quote-style posts.           |
+| reels-scripting      | content/generator.py + media/video_gen.py | Apify scrape + Gemini analysis + script writing. Full workflow in compose. |
+| youtube-thumbnail    | media/image_gen.py          | Thumbnail prompt builder. Relevant for video posts across platforms.       |
+| niche-research       | content/research.py         | Browser-driven research. Dashboard research page triggers it.              |
+| content-matrix       | content/generator.py        | Pillar x format ideation. Dashboard feature for content planning.          |
+| analytics-dashboard  | analytics/collector.py      | React dashboard logic migrates to the platform analytics page.             |
+| profile-optimizer    | Not directly integrated     | Standalone skill. Accessible via MCP but not embedded in dashboard.        |
+| pinned-comment       | Not directly integrated     | Standalone skill. Accessible via MCP but not embedded in dashboard.        |
+
+**Key insight:** 15 of 17 skills map directly to platform components. The content pipeline is already built in skill form. The platform wraps these skills in a dashboard UI, adds multi-platform adapters, and connects them through the approval queue.
+
+---
+
+## 10. Implementation roadmap
+
+### Phase 1: Foundation (weeks 1-3)
+
+**Goal:** Multi-platform adapter layer + dashboard shell
+
+- [ ] Refactor `facebook_api.py` into `adapters/facebook.py` implementing `PlatformAdapter`
+- [ ] Build `adapters/instagram.py` (shares Facebook Graph API, different endpoints)
+- [ ] Build adapter stubs for LinkedIn, X, TikTok (with clear "not yet configured" states)
+- [ ] Migrate approval queue from Slice 2 spec into `approval/` module
+- [ ] Build dashboard shell: FastAPI + HTMX, accounts page, settings page
+- [ ] SQLite schema: accounts, posts, request, tool_policy tables
+- [ ] Account management: add/remove accounts, store tokens, test connections
+
+**Deliverable:** Dashboard where you can connect Facebook + Instagram accounts and see them listed. Approval queue working for Facebook posts.
+
+### Phase 2: Content generation (weeks 4-6)
+
+**Goal:** Multi-AI content creation in the dashboard
+
+- [ ] Voice engine: load and parse about-me.md + voice.md
+- [ ] Content generator: Claude (MCP), OpenAI, Gemini text generation
+- [ ] Compose page with multi-platform preview
+- [ ] Platform content adaptation (character limits, hashtag rules, format constraints)
+- [ ] Hook generator integration (6 types from hook-generator skill)
+- [ ] Post scorer integration (5 criteria from post-scorer skill)
+- [ ] Image generation: DALL-E + Gemini prompt builder
+- [ ] Graphic designer: HTML/CSS path integrated into compose
+
+**Deliverable:** Write a post in the dashboard, generate it with AI, score it, preview per platform, submit for approval.
+
+### Phase 3: Publishing + scheduling (weeks 7-9)
+
+**Goal:** Approved posts actually publish
+
+- [ ] Facebook publishing (text, image, video)
+- [ ] Instagram publishing (photo, carousel, reel)
+- [ ] Scheduler: cron-style with optimal time suggestions
+- [ ] Rate limit tracking and enforcement per platform per account
+- [ ] Staggered publishing for batch operations
+- [ ] Retry logic for transient API failures
+- [ ] Post status tracking: draft to published pipeline in the database
+
+**Deliverable:** End-to-end flow: compose, approve, publish, verify.
+
+### Phase 4: Scale + remaining platforms (weeks 10-14)
+
+**Goal:** 100-page support + LinkedIn, X, TikTok
+
+- [ ] LinkedIn adapter (once Marketing Developer Platform approval received)
+- [ ] X adapter (once Pro tier subscription activated)
+- [ ] TikTok adapter (once Content Posting API approval received)
+- [ ] Batch compose: one post to N accounts
+- [ ] Batch approval: approve groups of related posts
+- [ ] Priority accounts and rate limit arbitration
+- [ ] Template system: save and reuse post templates across accounts
+
+**Deliverable:** All five platforms publishing. Batch operations working across 10+ accounts.
+
+### Phase 5: Analytics + intelligence (weeks 15-18)
+
+**Goal:** Cross-platform insights and automated optimisation
+
+- [ ] Analytics collector: pull insights from all connected platforms
+- [ ] Normalised metrics schema for cross-platform comparison
+- [ ] Analytics dashboard page with charts (Recharts or Chart.js via CDN)
+- [ ] Niche research integration (Apify-backed trend scanning)
+- [ ] Content matrix: pillar x format ideation in the dashboard
+- [ ] Reels scripting workflow: reference reel analysis to script
+- [ ] Feedback loop: publish results improve future scoring
+
+**Deliverable:** Full analytics dashboard. AI-driven content suggestions based on what performs.
+
+### Phase 6: Advanced automation (weeks 19-24)
+
+**Goal:** Hands-off operation for power users
+
+- [ ] Comment management: auto-reply templates, sentiment filtering
+- [ ] Ad creation workflow: "boost top performer" via Meta Marketing API (see 8)
+- [ ] Cross-posting intelligence: learn which content works on which platform
+- [ ] Video pipeline: ElevenLabs + HeyGen + Remotion integration
+- [ ] Notification system: email/Slack alerts for pending approvals, performance milestones
+- [ ] Multi-user support: team roles (creator, approver, admin)
+
+**Deliverable:** Platform runs with minimal daily attention. AI suggests, human approves, system publishes.
+
+---
+
+## 11. Technical decisions
+
+### 11.1 Why not a SPA?
+
+- No build step. Jinja2 + HTMX is deployable with `pip install` and no Node.js.
+- SSE for real-time updates is simpler than WebSocket state management.
+- The dashboard is a local tool for one user, not a public web app. Server-rendered is fine.
+- The existing Slice 2 spec already chose this stack.
+
+### 11.2 Why SQLite?
+
+- Zero configuration. No database server to install.
+- Single file, easy to back up.
+- WAL mode handles concurrent reads from dashboard + MCP server.
+- At 100 accounts with 10 posts/day each, we are at ~1000 rows/day. SQLite handles millions.
+
+### 11.3 Why adapters over a unified API?
+
+Each platform's API is different enough that a generic abstraction leaks. The adapter pattern lets each platform implement its own quirks (Instagram's container-based publishing, TikTok's inbox method, LinkedIn's URN-based entity system) while the dashboard code only calls the common interface.
+
+### 11.4 Token security
+
+- Access tokens stored encrypted in SQLite (Fernet symmetric encryption, key derived from a user-provided master password or machine-specific secret).
+- Tokens never logged in approval queue history.
+- Refresh token rotation handled per platform's OAuth spec.
+- `.env` file for API keys (OpenAI, Gemini, Apify) with `.gitignore` protection.
+
+---
+
+## 12. Risks and mitigations
+
+| Risk                                          | Impact  | Mitigation                                                                 |
+|-----------------------------------------------|---------|----------------------------------------------------------------------------|
+| LinkedIn app review rejected or delayed       | High    | Manual posting fallback. Prepare app submission documentation early.       |
+| TikTok app review rejected                    | Medium  | Inbox method (user confirms in app) as permanent fallback.                |
+| X Pro tier cost ($200/month) rejected by user | Low     | X integration is optional. Dashboard works without it.                    |
+| Instagram 25 publish/day limit hit            | High    | Rate limit tracking. Queue overflow to next day. Priority account system. |
+| AI provider API outage                        | Medium  | Multiple providers. Fallback chain: Claude -> OpenAI -> Gemini.          |
+| Token expiry during batch publish             | Medium  | Pre-flight token validation. Auto-refresh where supported.               |
+| 100 accounts overwhelms approval inbox        | High    | Batch approve, filters, templates, skip-approval option with safeguards. |
+| Voice drift across AI providers               | Medium  | Post-scorer validates voice match. Flag mismatches before approval.      |
+
+---
+
+## 13. Dependencies and prerequisites
+
+**Required before Phase 1:**
+- Python 3.11+
+- Facebook Developer App with Page Access Token
+- Instagram Professional Account linked to Facebook Page
+
+**Required before Phase 2:**
+- At least one AI provider API key (OpenAI, Gemini, or Claude via MCP)
+- Voice system built (run voice-builder skill)
+
+**Required before Phase 4:**
+- LinkedIn Marketing Developer Platform application submitted
+- X API Pro tier subscription ($200/month)
+- TikTok Developer Account with Content Posting API application submitted
+- Apify API token (for research and scraping features)
+
+**Optional (enhances but not required):**
+- ElevenLabs API key (voice synthesis for video)
+- HeyGen account (avatar video generation)
+- Nano Banana API key (alternative image generation)*
+- GOOGLE_AI_API_KEY (Gemini 2.5 Flash for video analysis)
+
+---
+
+## 14. Success criteria
+
+The platform is complete when a user can:
+
+1. Connect accounts across all five platforms from the dashboard
+2. Write one post and publish adapted versions to all connected platforms
+3. Generate post content using any of three AI providers with voice matching
+4. Generate images using DALL-E or Gemini from the compose page
+5. Score any draft against real historical performance data
+6. Review and approve every post before it publishes (or consciously skip approval)
+7. Schedule posts at optimal times per platform
+8. Manage 100 accounts without the approval queue becoming unusable
+9. View cross-platform analytics in a single dashboard
+10. Research trending topics and generate content ideas from the dashboard
+
+---
+
+*\* Nano Banana is user-mentioned and not yet evaluated. The pricing model and API availability have not been verified. Treat as a placeholder until confirmed.*
+
+*This document is the integration master plan. Each phase will produce its own detailed spec as implementation begins. The Slice 2 approval-queue spec is the first such detailed spec and fits inside Phase 1 of this roadmap.*


### PR DESCRIPTION
The README and CONTRIBUTING.md link to three documents that were deleted in earlier commits. With the project newly listed on `TensorBlock/awesome-mcp-servers`, those links resolve to 404s for incoming visitors.

Restoring from git history:

- `docs/specs/2026-05-02-multi-channel-platform-master-plan.md` (1032 lines)
- `docs/specs/2026-05-02-approval-queue-and-dashboard-mvp-design.md` (405 lines)
- `docs/integrations.md` (24 OSS projects, 94 lines)

Polish pass to update the master plan to current reality (4 live adapters, scheduler shipped, dashboard auth in flight) lands as a follow-up commit.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>