### PR TITLE
docs: Add Terms of Service and Privacy Policy

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -1,0 +1,56 @@
+# Privacy Policy
+
+Last updated: 2026-05-05
+
+## Summary
+
+social-auto-engine is self-hosted, open-source software. When you run it on your own infrastructure, all data stays on your server. The project maintainers do not collect, receive, or have access to any data from your installation.
+
+## What we collect
+
+Nothing. The maintainers of social-auto-engine operate no servers that receive your data, no analytics, and no telemetry. The project ships as source code and runs entirely on machines you control.
+
+If a hosted version is offered in the future, its privacy practices will be documented separately and presented at the point of sign-up.
+
+## What the software stores on your machine
+
+When you install and use the software on your own server, it stores the following locally only:
+
+- OAuth access tokens for the social platforms you choose to connect (Facebook, Instagram, WhatsApp, Threads, LinkedIn, TikTok). These are kept in a local environment file or token store on your server.
+- Posts you have drafted, scheduled, or published, including text, media references, and metadata.
+- Approval queue history (which user approved which post and when).
+- Application logs.
+
+By default this data sits in a local SQLite database at `~/.social-auto-engine/dashboard.db` and is never transmitted off your machine by the software itself.
+
+## What is sent to third parties
+
+The software communicates only with the official APIs of the platforms you have explicitly connected. For example, if you connect TikTok, the software talks to TikTok's API to upload videos and read profile information, using the OAuth token you provided. No data is routed through servers owned by the project maintainers.
+
+## Cookies and tracking
+
+The dashboard uses a session cookie only when you enable optional password protection. The software does not use any analytics, advertising, or tracking cookies.
+
+## Your rights and controls
+
+Because all data is stored on your own machine, you control it directly. You can:
+
+- Delete the local database file at any time to remove all stored data.
+- Revoke OAuth tokens through each platform's own settings.
+- Inspect or export the database directly using any SQLite tool.
+
+## Children's data
+
+The software is not intended for use by children under 13.
+
+## Security
+
+OAuth tokens are stored locally on your server. You are responsible for securing access to that server and the file system on which the database resides. The project follows reasonable engineering practice to avoid leaking credentials in logs or error output, and security issues can be reported via [github.com/Freespirits/social-auto-engine/issues](https://github.com/Freespirits/social-auto-engine/issues).
+
+## Changes to this policy
+
+This policy may be updated as the software evolves. Material changes will be announced in the project's changelog.
+
+## Contact
+
+For privacy questions, open an issue at [github.com/Freespirits/social-auto-engine/issues](https://github.com/Freespirits/social-auto-engine/issues).

--- a/TERMS.md
+++ b/TERMS.md
@@ -1,0 +1,44 @@
+# Terms of Service
+
+Last updated: 2026-05-05
+
+## What this is
+
+social-auto-engine is open-source software released under the MIT licence. It is a self-hosted scheduling and publishing tool for social media platforms including Facebook, Instagram, WhatsApp, Threads, LinkedIn, and TikTok.
+
+## How you use it
+
+1. You install the software on a server you control.
+2. You connect your own social media accounts using each platform's official OAuth flow.
+3. You author posts, queue them for review, and publish them at your discretion.
+
+## Your responsibilities
+
+By using social-auto-engine you agree that:
+
+- You are responsible for the content you publish through the software.
+- You will comply with the terms of service and developer policies of every platform you connect, including TikTok, Meta (Facebook, Instagram, WhatsApp, Threads), and LinkedIn.
+- You will not use the software to publish spam, harassment, malware, deceptive content, illegal material, or anything that violates a connected platform's rules.
+- You are responsible for the security of any credentials and OAuth tokens you provide to your installation.
+
+## Our responsibilities
+
+This software is provided as-is, without warranty of any kind. The project maintainers make reasonable efforts to keep the software safe and useful, but:
+
+- We do not guarantee uninterrupted service or feature availability.
+- We are not liable for damages, lost data, account suspensions, or any other harm arising from your use of the software.
+- We may change, deprecate, or remove features at any time.
+
+The full warranty disclaimer and liability terms are set out in the MIT licence shipped with the software.
+
+## Open source and contributions
+
+The source code is available at [github.com/Freespirits/social-auto-engine](https://github.com/Freespirits/social-auto-engine). You are welcome to inspect, fork, and contribute under the terms of the MIT licence.
+
+## Changes to these terms
+
+These terms may be updated as the software evolves. Material changes will be announced in the project's changelog.
+
+## Contact
+
+For questions, open an issue at [github.com/Freespirits/social-auto-engine/issues](https://github.com/Freespirits/social-auto-engine/issues).


### PR DESCRIPTION
## What

Adds `TERMS.md` and `PRIVACY.md` at the repo root.

## Why

TikTok's developer-app form and LinkedIn's Marketing Developer Platform both require linkable Terms and Privacy URLs. The GitHub blob URLs for these two files satisfy the requirement and read as legitimate to platform-review reviewers.

## Content

- **TERMS.md** describes the project's actual model (self-hosted, MIT, user is responsible for compliance with each platform's own ToS) and ships the standard MIT-style as-is disclaimer.
- **PRIVACY.md** is honest about the project shipping zero-data-collection: maintainers run no servers, all data stays in `~/.social-auto-engine/` on the user's machine.

## Test plan

- [ ] Both files render cleanly on the GitHub web UI.
- [ ] Paste `https://github.com/Freespirits/social-auto-engine/blob/main/TERMS.md` into the TikTok dev portal as the Terms URL when ready.
- [ ] Same for `PRIVACY.md` as the Privacy URL.

## Notes

This PR is a prerequisite for the LinkedIn / TikTok / YouTube developer-app submissions. It carries no code changes and can be merged at any time.