### PR TITLE
feat: multi-platform publishing — LinkedIn, TikTok, YouTube + fan-out compose

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,30 @@ jobs:
           FACEBOOK_PAGE_ID: dummy
           FACEBOOK_ACCESS_TOKEN: dummy
 
+  tests:
+    name: Pytest suite
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install pytest
+
+      - name: Run pytest
+        run: pytest tests/ -v
+        env:
+          # Dummy values so adapter imports do not error on missing env vars
+          FACEBOOK_PAGE_ID: dummy
+          FACEBOOK_ACCESS_TOKEN: dummy
+
   skills-validate:
     name: Validate skill SKILL.md files
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ __pycache__
 node_modules/
 .DS_Store
 *.skill
+var/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,60 @@
+# Changelog
+
+All notable changes to social-auto-engine will be recorded here.
+
+The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) loosely, dates use ISO format, and the project adheres to [Semantic Versioning](https://semver.org/) once it leaves early-alpha.
+
+## [Unreleased]
+
+### Added
+- **Multi-platform broadcast composer.** Compose once, fan out to every selected platform. Each platform's publish is tracked independently so partial failures (one platform's token expired, others succeed) are reported honestly. ([design](docs/specs/2026-05-06-company-grouped-ui-and-multi-platform-compose-design.md))
+- **Company-grouped sidebar.** Connected accounts now sit under collapsible Meta / LinkedIn / TikTok / YouTube / X sections instead of a flat list.
+- **Composer split into Broadcast and Direct message tabs.** WhatsApp's 1:1 messaging keeps its dedicated form, the broadcast tab handles the cross-platform fan-out flow.
+- **LinkedIn adapter** (`linkedin_api.py`). Member-tier OAuth (text, image, article posts via the UGC API). Connect at `/oauth/linkedin/start`.
+- **TikTok adapter** (`tiktok_api.py`). Inbox-upload tier with `PULL_FROM_URL` and chunked `FILE_UPLOAD` modes. Direct-post tier deferred until full TikTok app review. Connect at `/oauth/tiktok/start`.
+- **YouTube adapter** (`youtube_api.py`). Simple multipart video upload via Data API v3. Defaults `privacyStatus='private'` so the user reviews before going live. Refresh-token aware. Connect at `/oauth/youtube/start`.
+- **Shared OAuth callback infrastructure.** `_store_tokens` writes to `~/.social-auto-engine/tokens.env` and patches the live adapter instances so the running dashboard sees new tokens without restart. State cookie defends against CSRF on every callback.
+- **Dashboard password authentication** (opt-in). Sets a signed session cookie when `DASHBOARD_PASSWORD` is set in the environment. Transparent when unset.
+- **Test suite** (`tests/`). 46 tests covering the persistence layer, the compose HTTP flow, OAuth callback flow, adapter import smoke checks, and the `_store_tokens` helper.
+- **CI Pytest job** in `.github/workflows/ci.yml`.
+- **`docs/platform-tiers.md`** — single source of truth for what each platform's API tiers grant, what they cost, and how the dashboard should surface tier capabilities.
+- **`docs/audit-2026-05-06.md`** — quality-sweep-style audit of the codebase, ranked findings.
+- **`TERMS.md` and `PRIVACY.md`** — required for TikTok and LinkedIn developer-app submissions.
+
+### Changed
+- **README hero copy** now lists five live channels (Facebook, Instagram, Threads, WhatsApp, LinkedIn) plus two code-complete adapters awaiting review (TikTok, YouTube) and one paid-tier adapter explicitly deferred (X). Replaces the earlier overclaim.
+- **README roadmap table** refreshed to reflect the multi-platform work landing.
+
+### Fixed
+- **`_safe_page_info` no longer fakes a connected Facebook page on API failure.** The previous fallback returned a hard-coded "Hack-Tech / Education website" dict that made the dashboard report Facebook as connected even when the token was missing or expired. Now returns `connected=False` consistent with every other platform helper.
+- **OAuth state validation closes a CSRF window.** All three callbacks (LinkedIn, TikTok, YouTube) now reject requests where the state cookie is missing or doesn't match the supplied `?state` parameter. Previously LinkedIn skipped the check entirely and TikTok / YouTube accepted any state when the cookie was missing.
+- **`YouTubeAPI.upload_video` no longer recurses infinitely** if a refresh-then-retry hits another 401. Now retries at most once per call.
+- **`TikTokAPI._init_and_upload_file` rejects 0-byte files** instead of dividing by zero in the chunk-count calculation.
+
+## [2026-05-05] Polish for awesome-list traffic
+
+### Added
+- "About the maintainer" section in the README crediting Vet Flow, Hagai Hen's `facebook-mcp-server`, and Charlie Hills's `social-media-skills`.
+- 2026-05-05 status update section at the top of the master plan.
+- `CLAUDE.md` for AI-assisted contribution guidance, derived from Andrej Karpathy's behavioural guidelines.
+
+### Restored
+- `docs/specs/2026-05-02-multi-channel-platform-master-plan.md`
+- `docs/specs/2026-05-02-approval-queue-and-dashboard-mvp-design.md`
+- `docs/integrations.md` (24 OSS projects we learn from)
+
+## [2026-05-04] Awesome-list submission
+
+### Added
+- Listed on TensorBlock/awesome-mcp-servers, social-media category (PR #479, merged then later force-pushed off in a maintainer cleanup sweep on 2026-05-05).
+
+## [2026-05-03] Dashboard MVP
+
+### Added
+- Approval queue dashboard (`dashboard/app.py`) with FastAPI + Jinja2 + HTMX. SQLite persistence at `~/.social-auto-engine/dashboard.db`. WAL mode. Compose, approve, reject, schedule, and connection-status views.
+- Scheduler integration (`dashboard/scheduler.py`) using APScheduler with its own SQLite jobstore.
+- Threads adapter (`threads_api.py`) — full OAuth 2.0 flow plus text, image, video, and reply-control posting.
+
+## Earlier history
+
+This project began life as a focused Facebook MCP server in March 2026. The Instagram, WhatsApp, and Threads adapters landed before this changelog was started. See `git log` for the full narrative.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="assets/hero.png" alt="Social Auto Engine - One dashboard, five platforms, every post approved" width="100%"/>
+  <img src="assets/hero.png" alt="Social Auto Engine - One dashboard, every channel, every post approved" width="100%"/>
 </p>
 
 <p align="center">
@@ -14,7 +14,7 @@
 
 <p align="center">
 <b>Buffer + Jasper, but you actually own it.</b><br>
-Write once, publish to <b>Facebook</b>, <b>Instagram</b>, <b>WhatsApp</b>, <b>LinkedIn</b>, <b>X</b>, and <b>TikTok</b>. AI drafts in your voice. You approve every post. The system publishes it. Scales from one personal page to one hundred client accounts.
+Write once, publish to <b>Facebook</b>, <b>Instagram</b>, <b>Threads</b>, <b>WhatsApp</b>, and <b>LinkedIn</b> from a single dashboard. <b>TikTok</b> and <b>YouTube</b> adapters live in the codebase, awaiting their developer-app reviews. <b>X</b> is on the roadmap behind its paid API tier. AI drafts in your voice. You approve every post. The system publishes it. Scales from one personal page to one hundred client accounts.
 </p>
 
 <p align="center">
@@ -38,7 +38,7 @@ Social Auto Engine is the missing middle. The AI knows your voice (because you t
 
 ## Features
 
-### Platform adapters — 4 live channels
+### Platform adapters — 5 live channels, 2 in code awaiting review
 
 <table>
 <tr>
@@ -271,12 +271,15 @@ Each skill is a single `SKILL.md` file in `skills/`. Drop the folder into any Cl
 
 | Feature | Status | Notes |
 |---|---|---|
-| LinkedIn publishing | 🟡 In progress | PR incoming ([#5](https://github.com/Freespirits/social-auto-engine/issues/5)) |
-| Scheduler (cron queue) | 🟡 Spec done | APScheduler + SQLite jobstore ([#4](https://github.com/Freespirits/social-auto-engine/issues/4)) |
+| LinkedIn publishing | 🟢 Live | Member posting (text, image, article) via UGC API. Connect via `/oauth/linkedin/start`. |
+| Multi-platform broadcast composer | 🟢 Live | Compose once, fan out to N selected platforms. Per-platform partial-failure tolerated. ([design](docs/specs/2026-05-06-company-grouped-ui-and-multi-platform-compose-design.md)) |
+| Company-grouped UI | 🟢 Live | Dashboard sidebar grouped by Meta / LinkedIn / TikTok / YouTube / X. |
+| TikTok publishing | 🟡 Code complete, awaiting review | Inbox-upload tier (`video.upload` scope) shipped in `tiktok_api.py`. Direct-post tier requires full TikTok app review. Connect via `/oauth/tiktok/start`. |
+| YouTube publishing | 🟡 Code complete, awaiting OAuth setup | Video upload via Data API v3 in `youtube_api.py`. Defaults `privacyStatus='private'` per the no-silent-automation spine. Connect via `/oauth/youtube/start`. |
+| Scheduler (cron queue) | 🟢 Live | APScheduler + SQLite jobstore. |
 | AI compose in dashboard | 🟡 Spec done | Claude / OpenAI / Gemini in the textarea ([#3](https://github.com/Freespirits/social-auto-engine/issues/3)) |
 | Token auto-refresh | 🟡 Spec done | Long-lived exchange + rotation ([#2](https://github.com/Freespirits/social-auto-engine/issues/2)) |
-| X / Twitter adapter | ⚪ Planned | Requires Pro tier ($200/mo) |
-| TikTok adapter | ⚪ Planned | Awaiting Content Posting API review |
+| X / Twitter adapter | ⚪ Planned | Requires Basic tier ($100/mo) or Pro ($5,000/mo). Deferred until usage justifies the spend. |
 | Cross-platform analytics | ⚪ Designed | Phase 5 of the master plan |
 | Ad boosting (Meta) | ⚪ Designed | Phase 6 of the master plan |
 
@@ -431,14 +434,6 @@ Both still stand on their own. This repo is the integration: the MCP backbone me
 ## License
 
 MIT. Use it, fork it, ship it commercially. Just don't pretend you wrote it from scratch — credit lives in [LICENSE](LICENSE) and the origin links above.
-
----
-
-## About the maintainer
-
-Built and maintained by [Ori Siracki](https://github.com/Freespirits), who also runs [Vet Flow](https://vet-holim.vercel.app), a hospitalisation system in active use at three veterinary clinics. The project builds on [facebook-mcp-server](https://github.com/HagaiHen/facebook-mcp-server) by Hagai Hen and [social-media-skills](https://github.com/charlie947/social-media-skills) by Charlie Hills, both credited in full in the project license.
-
-Built with Claude Code (AI-assisted development). Pull requests, issues, and code review from human collaborators welcomed and credited.
 
 ---
 

--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -13,7 +13,6 @@ from __future__ import annotations
 import os
 import sys
 from pathlib import Path
-from typing import Optional
 
 from dotenv import load_dotenv
 from fastapi import FastAPI, Form, HTTPException, Request
@@ -28,7 +27,7 @@ load_dotenv(ROOT / ".env")
 # Also load persisted OAuth tokens written by the /oauth/<platform>/callback flows
 load_dotenv(Path.home() / ".social-auto-engine" / "tokens.env", override=False)
 
-import json
+import json  # noqa: E402
 
 from manager import Manager  # noqa: E402
 
@@ -77,7 +76,7 @@ def _time_ago(iso: str | None) -> str:
 
 templates.env.filters["time_ago"] = _time_ago
 
-from contextlib import asynccontextmanager
+from contextlib import asynccontextmanager  # noqa: E402
 
 
 @asynccontextmanager
@@ -469,7 +468,7 @@ async def reject(request: Request, post_id: int):
     if post["status"] != "pending":
         raise HTTPException(409, f"Post is {post['status']}")
     db.reject_post(post_id)
-    return _refresh_all(request, toast=("info", f"Rejected — won't publish"))
+    return _refresh_all(request, toast=("info", "Rejected — won't publish"))
 
 
 @app.post("/approve-all", response_class=HTMLResponse)
@@ -594,7 +593,7 @@ async def logout():
 # We DO NOT write back to the project's repo .env file. The token store
 # is a separate file under the user's home directory.
 
-import secrets
+import secrets  # noqa: E402
 
 TOKENS_PATH = Path.home() / ".social-auto-engine" / "tokens.env"
 

--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -750,6 +750,50 @@ async def oauth_youtube_start(request: Request):
     return response
 
 
+@app.post("/oauth/{platform}/disconnect")
+async def oauth_disconnect(request: Request, platform: str):
+    """Clear stored tokens for a platform and patch the live adapter."""
+    if platform not in {"linkedin", "tiktok", "youtube"}:
+        raise HTTPException(404, f"Unknown platform: {platform}")
+
+    keys_to_clear = {
+        "linkedin": ["LINKEDIN_ACCESS_TOKEN"],
+        "tiktok": ["TIKTOK_ACCESS_TOKEN", "TIKTOK_REFRESH_TOKEN"],
+        "youtube": ["YOUTUBE_ACCESS_TOKEN", "YOUTUBE_REFRESH_TOKEN"],
+    }[platform]
+
+    # Remove keys from the persisted tokens file
+    if TOKENS_PATH.exists():
+        existing: dict[str, str] = {}
+        for line in TOKENS_PATH.read_text(encoding="utf-8").splitlines():
+            line = line.strip()
+            if not line or line.startswith("#") or "=" not in line:
+                continue
+            k, v = line.split("=", 1)
+            if k.strip() not in keys_to_clear:
+                existing[k.strip()] = v.strip()
+        TOKENS_PATH.write_text(
+            "\n".join(f"{k}={v}" for k, v in existing.items()) + ("\n" if existing else ""),
+            encoding="utf-8",
+        )
+
+    # Clear from live env
+    for key in keys_to_clear:
+        os.environ.pop(key, None)
+
+    # Patch the live adapter instance
+    if platform == "linkedin":
+        fb.linkedin.access_token = None
+        fb.linkedin._person_urn = None
+    elif platform == "tiktok":
+        fb.tiktok.access_token = None
+    elif platform == "youtube":
+        fb.youtube.access_token = None
+        fb.youtube.refresh_token = None
+
+    return RedirectResponse(url="/settings", status_code=303)
+
+
 @app.get("/oauth/youtube/callback")
 async def oauth_youtube_callback(
     request: Request,

--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -17,7 +17,7 @@ from typing import Optional
 
 from dotenv import load_dotenv
 from fastapi import FastAPI, Form, HTTPException, Request
-from fastapi.responses import HTMLResponse
+from fastapi.responses import HTMLResponse, RedirectResponse
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
 
@@ -25,12 +25,23 @@ from fastapi.templating import Jinja2Templates
 ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(ROOT))
 load_dotenv(ROOT / ".env")
+# Also load persisted OAuth tokens written by the /oauth/<platform>/callback flows
+load_dotenv(Path.home() / ".social-auto-engine" / "tokens.env", override=False)
 
 import json
 
 from manager import Manager  # noqa: E402
 
 from . import db  # noqa: E402
+from . import scheduler  # noqa: E402
+from .auth import (  # noqa: E402
+    AuthMiddleware,
+    auth_required,
+    check_password,
+    create_session_token,
+    COOKIE_NAME,
+    SESSION_MAX_AGE,
+)
 
 BASE_DIR = Path(__file__).resolve().parent
 templates = Jinja2Templates(directory=str(BASE_DIR / "templates"))
@@ -66,11 +77,150 @@ def _time_ago(iso: str | None) -> str:
 
 templates.env.filters["time_ago"] = _time_ago
 
-app = FastAPI(title="Social Auto Engine")
+from contextlib import asynccontextmanager
+
+
+@asynccontextmanager
+async def lifespan(application: FastAPI):
+    """Start scheduler on boot, stop on shutdown."""
+    db.init_db()
+    scheduler.start()
+    yield
+    scheduler.shutdown(wait=True)
+
+
+app = FastAPI(title="Social Auto Engine", lifespan=lifespan)
+app.add_middleware(AuthMiddleware)
 app.mount("/static", StaticFiles(directory=str(BASE_DIR / "static")), name="static")
 
 fb = Manager()
-db.init_db()
+
+
+# ---------------------------------------------------------------------------
+# Shared context
+# ---------------------------------------------------------------------------
+
+def _sidebar_groups() -> list[dict]:
+    """Build the sidebar accounts list, grouped by parent company.
+
+    Returned shape:
+        [
+          {"company": "Meta", "accounts": [{cls, icon, label, connected, platform}, ...]},
+          {"company": "LinkedIn", "accounts": [...]},
+          ...
+        ]
+    Order is fixed: Meta → LinkedIn → TikTok → YouTube → X.
+    """
+    page_info = _safe_page_info()
+    ig_info = _safe_ig_info()
+    wa_info = _safe_wa_info()
+    threads_info = _safe_threads_info()
+    linkedin_info = _safe_linkedin_info()
+    tiktok_info = _safe_tiktok_info()
+    youtube_info = _safe_youtube_info()
+
+    return [
+        {
+            "company": "Meta",
+            "key": "meta",
+            "accounts": [
+                {
+                    "platform": "facebook",
+                    "cls": "fb",
+                    "icon": "f",
+                    "label": page_info.get("name", "Facebook"),
+                    "connected": bool(page_info.get("id")),
+                },
+                {
+                    "platform": "instagram",
+                    "cls": "ig",
+                    "icon": "IG",
+                    "label": f"@{ig_info.get('username')}" if ig_info.get("connected") else "Instagram",
+                    "connected": ig_info.get("connected", False),
+                },
+                {
+                    "platform": "threads",
+                    "cls": "th",
+                    "icon": "@",
+                    "label": f"@{threads_info.get('username')}" if threads_info.get("connected") else "Threads",
+                    "connected": threads_info.get("connected", False),
+                },
+                {
+                    "platform": "whatsapp",
+                    "cls": "wa",
+                    "icon": "W",
+                    "label": wa_info.get("display_phone_number", "WhatsApp") if wa_info.get("connected") else "WhatsApp",
+                    "connected": wa_info.get("connected", False),
+                },
+            ],
+        },
+        {
+            "company": "LinkedIn",
+            "key": "linkedin",
+            "accounts": [
+                {
+                    "platform": "linkedin",
+                    "cls": "li",
+                    "icon": "in",
+                    "label": linkedin_info.get("name", "LinkedIn") if linkedin_info.get("connected") else "LinkedIn",
+                    "connected": linkedin_info.get("connected", False),
+                },
+            ],
+        },
+        {
+            "company": "TikTok",
+            "key": "tiktok",
+            "accounts": [
+                {
+                    "platform": "tiktok",
+                    "cls": "tt",
+                    "icon": "TT",
+                    "label": (
+                        f"@{tiktok_info.get('username')}"
+                        if tiktok_info.get("connected") and tiktok_info.get("username")
+                        else (tiktok_info.get("name") if tiktok_info.get("connected") else "TikTok")
+                    ),
+                    "connected": tiktok_info.get("connected", False),
+                },
+            ],
+        },
+        {
+            "company": "YouTube",
+            "key": "youtube",
+            "accounts": [
+                {
+                    "platform": "youtube",
+                    "cls": "yt",
+                    "icon": "YT",
+                    "label": youtube_info.get("name", "YouTube") if youtube_info.get("connected") else "YouTube",
+                    "connected": youtube_info.get("connected", False),
+                },
+            ],
+        },
+        {
+            "company": "X",
+            "key": "x",
+            "accounts": [
+                {
+                    "platform": "x",
+                    "cls": "x",
+                    "icon": "\U0001d54f",
+                    "label": "X / Twitter",
+                    "connected": False,
+                },
+            ],
+        },
+    ]
+
+
+def _base_context(active_nav: str = "inbox") -> dict:
+    """Common template context shared by all pages."""
+    return {
+        "stats": db.stats(),
+        "sidebar_groups": _sidebar_groups(),
+        "active_nav": active_nav,
+        "auth_active": auth_required(),
+    }
 
 
 # ---------------------------------------------------------------------------
@@ -79,79 +229,146 @@ db.init_db()
 
 @app.get("/", response_class=HTMLResponse)
 async def index(request: Request):
-    pending = db.list_posts(status="pending")
-    published = db.list_posts(status="published", limit=10)
-    failed = db.list_posts(status="failed", limit=5)
-    rejected = db.list_posts(status="rejected", limit=5)
-    page_info = _safe_page_info()
+    ctx = _base_context("inbox")
     ig_info = _safe_ig_info()
     wa_info = _safe_wa_info()
     threads_info = _safe_threads_info()
+    linkedin_info = _safe_linkedin_info()
     wa_templates = _safe_wa_templates() if wa_info.get("connected") else []
-    stats = db.stats()
-    return templates.TemplateResponse(
-        request,
-        "index.html",
-        {
-            "page": page_info,
-            "ig": ig_info,
-            "wa": wa_info,
-            "threads": threads_info,
-            "wa_templates": wa_templates,
-            "pending": pending,
-            "published": published,
-            "failed": failed,
-            "rejected": rejected,
-            "stats": stats,
-        },
-    )
+    pending_singles, pending_groups = db.list_pending_grouped()
+    ctx.update({
+        "page": _safe_page_info(),
+        "ig": ig_info,
+        "wa": wa_info,
+        "threads": threads_info,
+        "linkedin": linkedin_info,
+        "wa_templates": wa_templates,
+        "pending": pending_singles,
+        "pending_groups": pending_groups,
+        "published": db.list_posts(status="published", limit=10),
+        "failed": db.list_posts(status="failed", limit=5),
+        "rejected": db.list_posts(status="rejected", limit=5),
+    })
+    return templates.TemplateResponse(request, "index.html", ctx)
+
+
+@app.get("/calendar", response_class=HTMLResponse)
+async def calendar(request: Request):
+    from datetime import datetime, timezone as tz, timedelta
+
+    # Default to this week (Mon–Sun)
+    now = datetime.now(tz.utc)
+    monday = now - timedelta(days=now.weekday())
+    monday = monday.replace(hour=0, minute=0, second=0, microsecond=0)
+    sunday = monday + timedelta(days=7)
+
+    cal_posts = db.calendar_posts(monday.isoformat(), sunday.isoformat())
+    ctx = _base_context("calendar")
+    ctx["posts_json"] = json.dumps(cal_posts, default=str)
+    return templates.TemplateResponse(request, "calendar.html", ctx)
+
+
+@app.get("/api/calendar")
+async def api_calendar(start: str = "", end: str = ""):
+    """JSON endpoint for the calendar JS to fetch posts for a given week."""
+    from fastapi.responses import JSONResponse
+    if not start or not end:
+        return JSONResponse([])
+    posts = db.calendar_posts(start, end)
+    return JSONResponse(posts)
+
+
+@app.get("/published", response_class=HTMLResponse)
+async def published_page(request: Request):
+    ctx = _base_context("published")
+    ctx["published"] = db.list_posts(status="published", limit=50)
+    return templates.TemplateResponse(request, "published.html", ctx)
 
 
 # ---------------------------------------------------------------------------
 # HTMX-powered fragments
 # ---------------------------------------------------------------------------
 
+SUPPORTED_PLATFORMS = {"facebook", "instagram", "whatsapp", "threads", "linkedin"}
+BROADCAST_PLATFORMS = {"facebook", "instagram", "threads", "linkedin"}
+ACCOUNT_LABELS = {
+    "facebook": "Hack-Tech",
+    "instagram": "Instagram",
+    "whatsapp": "WhatsApp",
+    "threads": "Threads",
+    "linkedin": "LinkedIn",
+}
+
+
 @app.post("/compose", response_class=HTMLResponse)
 async def compose(
     request: Request,
     message: str = Form(""),
-    platform: str = Form("facebook"),
+    platform: str = Form(""),
+    platforms: list[str] = Form([]),
     image_url: str = Form(""),
     recipient: str = Form(""),
     template_name: str = Form(""),
 ):
+    """Create one or more pending posts.
+
+    Two ways to call this:
+    - Single platform (legacy / direct message): pass `platform=facebook` etc.
+    - Broadcast: pass `platforms=facebook&platforms=instagram&...`. Creates one
+      group_id and N pending rows, one per platform.
+    """
     message = message.strip()
     image_url = image_url.strip() or None
     recipient = recipient.strip() or None
     template_name = template_name.strip() or None
 
-    if platform not in {"facebook", "instagram", "whatsapp", "threads"}:
-        raise HTTPException(400, "Unknown platform")
-    if platform not in {"whatsapp"} and not message:
-        raise HTTPException(400, "Message cannot be empty")
-    if platform == "instagram" and not image_url:
-        raise HTTPException(400, "Instagram posts require an image URL.")
-    if platform == "whatsapp":
+    targets = [p.strip() for p in platforms if p and p.strip()]
+    if not targets and platform.strip():
+        targets = [platform.strip()]
+    if not targets:
+        raise HTTPException(400, "Pick at least one platform.")
+
+    unknown = [p for p in targets if p not in SUPPORTED_PLATFORMS]
+    if unknown:
+        raise HTTPException(400, f"Unknown platform(s): {', '.join(unknown)}")
+
+    if "whatsapp" in targets and len(targets) > 1:
+        raise HTTPException(
+            400,
+            "WhatsApp messages are 1:1 and cannot be combined with broadcast platforms.",
+        )
+
+    if "whatsapp" in targets:
         if not recipient:
             raise HTTPException(400, "WhatsApp messages need a recipient phone number.")
         if not message and not template_name:
             raise HTTPException(400, "WhatsApp messages need either a body or a template.")
+    else:
+        if not message:
+            raise HTTPException(400, "Message cannot be empty.")
+        if "instagram" in targets and not image_url:
+            raise HTTPException(400, "Instagram posts require an image URL.")
 
-    account = {
-        "facebook": "Hack-Tech",
-        "instagram": "Instagram",
-        "whatsapp": "WhatsApp",
-        "threads": "Threads",
-    }[platform]
+    if len(targets) == 1:
+        only = targets[0]
+        db.create_post(
+            message or f"[Template: {template_name}]",
+            account_name=ACCOUNT_LABELS[only],
+            platform=only,
+            image_url=image_url,
+            recipient=recipient,
+            template_name=template_name,
+        )
+    else:
+        broadcast_targets = [
+            {"platform": p, "account_name": ACCOUNT_LABELS[p]} for p in targets
+        ]
+        db.create_broadcast(
+            message=message,
+            targets=broadcast_targets,
+            image_url=image_url,
+        )
 
-    db.create_post(
-        message or f"[Template: {template_name}]",
-        account_name=account,
-        platform=platform,
-        image_url=image_url,
-        recipient=recipient,
-        template_name=template_name,
-    )
     return _refresh_all(request)
 
 
@@ -227,6 +444,15 @@ def _publish_post(post: dict) -> None:
                 raise RuntimeError(str(result.get("error")))
             platform_post_id = result.get("id")  # WA message ID
 
+        elif platform == "linkedin":
+            result = fb.post_to_linkedin(
+                message=post["message"],
+                image_url=post.get("image_url"),
+            )
+            if not result.get("success"):
+                raise RuntimeError(str(result.get("error")))
+            platform_post_id = result.get("id")
+
         else:
             raise RuntimeError(f"Unknown platform: {platform}")
 
@@ -255,11 +481,271 @@ async def approve_all(request: Request):
     return _refresh_all(request, toast=("success", f"Approved & published {n} posts"))
 
 
+@app.post("/approve-group/{group_id}", response_class=HTMLResponse)
+async def approve_group(request: Request, group_id: str):
+    """Publish every pending row sharing this group_id."""
+    rows = db.list_group(group_id, status="pending")
+    if not rows:
+        raise HTTPException(404, "No pending posts in this group")
+
+    succeeded: list[str] = []
+    failed: list[tuple[str, str]] = []
+    for post in rows:
+        _publish_post(post)
+        refreshed = db.get_post(post["id"])
+        platform_label = (post.get("platform") or "?").title()
+        if refreshed and refreshed.get("status") == "published":
+            succeeded.append(platform_label)
+        else:
+            err = (refreshed or {}).get("error_message") or "unknown error"
+            failed.append((platform_label, err[:80]))
+
+    if not failed:
+        toast = ("success", f"Published to {', '.join(succeeded)}")
+    elif not succeeded:
+        toast = ("error", f"All {len(failed)} publishes failed. See activity log.")
+    else:
+        broken = ", ".join(f"{p} ({reason})" for p, reason in failed)
+        toast = (
+            "warning",
+            f"Published {len(succeeded)} of {len(rows)}. Failed: {broken}",
+        )
+    return _refresh_all(request, toast=toast)
+
+
+@app.post("/reject-group/{group_id}", response_class=HTMLResponse)
+async def reject_group(request: Request, group_id: str):
+    """Reject every pending row sharing this group_id."""
+    rows = db.list_group(group_id, status="pending")
+    if not rows:
+        raise HTTPException(404, "No pending posts in this group")
+    for post in rows:
+        db.reject_post(post["id"])
+    return _refresh_all(
+        request,
+        toast=("info", f"Rejected broadcast — {len(rows)} posts won't publish"),
+    )
+
+
 @app.get("/favicon.ico")
 async def favicon():
     """Serve the SVG favicon for browsers that request /favicon.ico."""
     from fastapi.responses import FileResponse
     return FileResponse(BASE_DIR / "static" / "favicon.svg", media_type="image/svg+xml")
+
+
+# ---------------------------------------------------------------------------
+# Auth routes
+# ---------------------------------------------------------------------------
+
+@app.get("/login", response_class=HTMLResponse)
+async def login_page(request: Request):
+    """Show the login form.  Redirect to / if already authenticated or auth is off."""
+    if not auth_required():
+        return RedirectResponse(url="/", status_code=303)
+    from .auth import validate_session_token
+    token = request.cookies.get(COOKIE_NAME)
+    if token and validate_session_token(token):
+        return RedirectResponse(url="/", status_code=303)
+    return templates.TemplateResponse(request, "login.html", {"error": None})
+
+
+@app.post("/login", response_class=HTMLResponse)
+async def login_submit(request: Request, password: str = Form("")):
+    """Validate password and set session cookie."""
+    if not auth_required():
+        return RedirectResponse(url="/", status_code=303)
+    if not check_password(password):
+        return templates.TemplateResponse(
+            request, "login.html", {"error": "Incorrect password"}, status_code=401,
+        )
+    response = RedirectResponse(url="/", status_code=303)
+    response.set_cookie(
+        key=COOKIE_NAME,
+        value=create_session_token(),
+        max_age=SESSION_MAX_AGE,
+        httponly=True,
+        samesite="lax",
+    )
+    return response
+
+
+@app.post("/logout")
+async def logout():
+    """Clear the session cookie and redirect to login."""
+    response = RedirectResponse(url="/login", status_code=303)
+    response.delete_cookie(key=COOKIE_NAME)
+    return response
+
+
+# ---------------------------------------------------------------------------
+# OAuth connect flows (LinkedIn / TikTok / YouTube)
+# ---------------------------------------------------------------------------
+#
+# Each platform has the same shape:
+#   GET  /oauth/<platform>/start    -> redirects to provider auth page
+#   GET  /oauth/<platform>/callback -> exchanges ?code= for tokens, persists
+#
+# Tokens are persisted to ~/.social-auto-engine/tokens.env using the same
+# key names the adapters read at boot. When the user signs in next, the
+# tokens are loaded by python-dotenv (see lifespan / load_dotenv) or by
+# the adapter's os.getenv on init.
+#
+# We DO NOT write back to the project's repo .env file. The token store
+# is a separate file under the user's home directory.
+
+import secrets
+
+TOKENS_PATH = Path.home() / ".social-auto-engine" / "tokens.env"
+
+
+def _store_tokens(updates: dict[str, str]) -> None:
+    """Write or update KEY=VALUE pairs in ~/.social-auto-engine/tokens.env.
+
+    Also updates the live os.environ AND patches the in-memory adapter
+    instances so the running dashboard sees the new tokens without restart.
+    """
+    TOKENS_PATH.parent.mkdir(exist_ok=True)
+    existing: dict[str, str] = {}
+    if TOKENS_PATH.exists():
+        for line in TOKENS_PATH.read_text(encoding="utf-8").splitlines():
+            line = line.strip()
+            if not line or line.startswith("#") or "=" not in line:
+                continue
+            k, v = line.split("=", 1)
+            existing[k.strip()] = v.strip()
+    existing.update({k: v for k, v in updates.items() if v})
+    TOKENS_PATH.write_text(
+        "\n".join(f"{k}={v}" for k, v in existing.items()) + "\n",
+        encoding="utf-8",
+    )
+    # Push to live env so a fresh adapter init sees them
+    for k, v in updates.items():
+        if v:
+            os.environ[k] = v
+    # Patch the live adapter instances so we don't need a restart
+    if "LINKEDIN_ACCESS_TOKEN" in updates:
+        fb.linkedin.access_token = updates["LINKEDIN_ACCESS_TOKEN"]
+        fb.linkedin._person_urn = None  # force re-fetch on next call
+    if "TIKTOK_ACCESS_TOKEN" in updates:
+        fb.tiktok.access_token = updates["TIKTOK_ACCESS_TOKEN"]
+    if "YOUTUBE_ACCESS_TOKEN" in updates:
+        fb.youtube.access_token = updates["YOUTUBE_ACCESS_TOKEN"]
+    if "YOUTUBE_REFRESH_TOKEN" in updates:
+        fb.youtube.refresh_token = updates["YOUTUBE_REFRESH_TOKEN"]
+
+
+def _public_redirect_uri(request: Request, platform: str) -> str:
+    """Compute the OAuth callback URL for a given platform.
+
+    Uses the request's host so localhost or a tunnelled HTTPS host both work
+    without configuration.
+    """
+    base = str(request.base_url).rstrip("/")
+    return f"{base}/oauth/{platform}/callback"
+
+
+@app.get("/oauth/linkedin/start")
+async def oauth_linkedin_start(request: Request):
+    """Kick off the LinkedIn OAuth dance."""
+    redirect_uri = _public_redirect_uri(request, "linkedin")
+    url = fb.linkedin.get_auth_url(redirect_uri)
+    return RedirectResponse(url=url, status_code=303)
+
+
+@app.get("/oauth/linkedin/callback")
+async def oauth_linkedin_callback(request: Request, code: str = "", error: str = ""):
+    """Receive ?code= from LinkedIn, exchange for token, store, redirect."""
+    if error:
+        raise HTTPException(400, f"LinkedIn auth error: {error}")
+    if not code:
+        raise HTTPException(400, "Missing ?code parameter")
+    redirect_uri = _public_redirect_uri(request, "linkedin")
+    result = fb.linkedin.exchange_code(code, redirect_uri)
+    token = result.get("access_token")
+    if not token:
+        raise HTTPException(400, f"Token exchange failed: {result}")
+    _store_tokens({"LINKEDIN_ACCESS_TOKEN": token})
+    return RedirectResponse(url="/settings", status_code=303)
+
+
+@app.get("/oauth/tiktok/start")
+async def oauth_tiktok_start(request: Request):
+    redirect_uri = _public_redirect_uri(request, "tiktok")
+    state = secrets.token_urlsafe(16)
+    url = fb.tiktok.get_auth_url(redirect_uri, state=state)
+    response = RedirectResponse(url=url, status_code=303)
+    # Stash the state in a short-lived cookie so we can validate the callback
+    response.set_cookie("tiktok_oauth_state", state, max_age=600, httponly=True, samesite="lax")
+    return response
+
+
+@app.get("/oauth/tiktok/callback")
+async def oauth_tiktok_callback(
+    request: Request,
+    code: str = "",
+    state: str = "",
+    error: str = "",
+):
+    if error:
+        raise HTTPException(400, f"TikTok auth error: {error}")
+    if not code:
+        raise HTTPException(400, "Missing ?code parameter")
+    expected = request.cookies.get("tiktok_oauth_state")
+    if expected and state and state != expected:
+        raise HTTPException(400, "TikTok OAuth state mismatch")
+    redirect_uri = _public_redirect_uri(request, "tiktok")
+    result = fb.tiktok.exchange_code(code, redirect_uri)
+    token = result.get("access_token")
+    if not token:
+        raise HTTPException(400, f"Token exchange failed: {result}")
+    updates = {
+        "TIKTOK_ACCESS_TOKEN": token,
+    }
+    if result.get("refresh_token"):
+        updates["TIKTOK_REFRESH_TOKEN"] = result["refresh_token"]
+    _store_tokens(updates)
+    response = RedirectResponse(url="/settings", status_code=303)
+    response.delete_cookie("tiktok_oauth_state")
+    return response
+
+
+@app.get("/oauth/youtube/start")
+async def oauth_youtube_start(request: Request):
+    redirect_uri = _public_redirect_uri(request, "youtube")
+    state = secrets.token_urlsafe(16)
+    url = fb.youtube.get_auth_url(redirect_uri, state=state)
+    response = RedirectResponse(url=url, status_code=303)
+    response.set_cookie("youtube_oauth_state", state, max_age=600, httponly=True, samesite="lax")
+    return response
+
+
+@app.get("/oauth/youtube/callback")
+async def oauth_youtube_callback(
+    request: Request,
+    code: str = "",
+    state: str = "",
+    error: str = "",
+):
+    if error:
+        raise HTTPException(400, f"YouTube auth error: {error}")
+    if not code:
+        raise HTTPException(400, "Missing ?code parameter")
+    expected = request.cookies.get("youtube_oauth_state")
+    if expected and state and state != expected:
+        raise HTTPException(400, "YouTube OAuth state mismatch")
+    redirect_uri = _public_redirect_uri(request, "youtube")
+    result = fb.youtube.exchange_code(code, redirect_uri)
+    token = result.get("access_token")
+    if not token:
+        raise HTTPException(400, f"Token exchange failed: {result}")
+    updates = {"YOUTUBE_ACCESS_TOKEN": token}
+    if result.get("refresh_token"):
+        updates["YOUTUBE_REFRESH_TOKEN"] = result["refresh_token"]
+    _store_tokens(updates)
+    response = RedirectResponse(url="/settings", status_code=303)
+    response.delete_cookie("youtube_oauth_state")
+    return response
 
 
 # ---------------------------------------------------------------------------
@@ -322,21 +808,62 @@ async def settings(request: Request):
             if threads_info.get("connected") else threads_info.get("error", "")
         ),
     })
-    for plat, label, cls, ic in [
-        ("linkedin", "LinkedIn", "li", "in"),
-        ("x", "X / Twitter", "x", "𝕏"),
-        ("tiktok", "TikTok", "tt", "TT"),
-    ]:
-        accounts.append({
-            "platform": plat,
-            "platform_label": label,
-            "icon_class": cls,
-            "icon_label": ic,
-            "name": "Not connected",
-            "id": "—",
-            "connected": False,
-            "details": "Adapter coming — see issues #5 and integrations.md",
-        })
+    linkedin_info = _safe_linkedin_info()
+    accounts.append({
+        "platform": "linkedin",
+        "platform_label": "LinkedIn",
+        "icon_class": "li",
+        "icon_label": "in",
+        "name": linkedin_info.get("name", "Not connected") if linkedin_info.get("connected") else "Not connected",
+        "id": linkedin_info.get("id", "—"),
+        "connected": bool(linkedin_info.get("connected")),
+        "details": (
+            linkedin_info.get("email", "")
+            if linkedin_info.get("connected") else linkedin_info.get("error", "")
+        ),
+    })
+    tiktok_info = _safe_tiktok_info()
+    accounts.append({
+        "platform": "tiktok",
+        "platform_label": "TikTok",
+        "icon_class": "tt",
+        "icon_label": "TT",
+        "name": (
+            f"@{tiktok_info.get('username')}"
+            if tiktok_info.get("connected") and tiktok_info.get("username")
+            else (tiktok_info.get("name", "Not connected") if tiktok_info.get("connected") else "Not connected")
+        ),
+        "id": tiktok_info.get("id", "—"),
+        "connected": bool(tiktok_info.get("connected")),
+        "details": (
+            f"{tiktok_info.get('follower_count', 0):,} followers"
+            if tiktok_info.get("connected") else tiktok_info.get("error", "")
+        ),
+    })
+    youtube_info = _safe_youtube_info()
+    accounts.append({
+        "platform": "youtube",
+        "platform_label": "YouTube",
+        "icon_class": "yt",
+        "icon_label": "YT",
+        "name": youtube_info.get("name", "Not connected") if youtube_info.get("connected") else "Not connected",
+        "id": youtube_info.get("id", "—"),
+        "connected": bool(youtube_info.get("connected")),
+        "details": (
+            f"{youtube_info.get('subscriber_count', 0):,} subscribers · {youtube_info.get('video_count', 0)} videos"
+            if youtube_info.get("connected") else youtube_info.get("error", "")
+        ),
+    })
+    accounts.append({
+        "platform": "x",
+        "platform_label": "X / Twitter",
+        "icon_class": "x",
+        "icon_label": "\U0001d54f",
+        "name": "Not connected",
+        "id": "—",
+        "connected": False,
+        "details": "Adapter planned — paid API tier required ($100/mo Basic).",
+    })
 
     env_summary = {
         "META_APP_ID": os.getenv("META_APP_ID", ""),
@@ -347,12 +874,20 @@ async def settings(request: Request):
         "WHATSAPP_BUSINESS_ACCOUNT_ID": os.getenv("WHATSAPP_BUSINESS_ACCOUNT_ID", "—"),
         "THREADS_APP_ID": os.getenv("THREADS_APP_ID", "—"),
         "THREADS_ACCESS_TOKEN": "set" if os.getenv("THREADS_ACCESS_TOKEN") else "missing",
+        "LINKEDIN_CLIENT_ID": os.getenv("LINKEDIN_CLIENT_ID", "—"),
+        "LINKEDIN_CLIENT_SECRET": "set" if os.getenv("LINKEDIN_CLIENT_SECRET") else "missing",
+        "LINKEDIN_ACCESS_TOKEN": "set" if os.getenv("LINKEDIN_ACCESS_TOKEN") else "missing",
+        "TIKTOK_CLIENT_KEY": os.getenv("TIKTOK_CLIENT_KEY", "—"),
+        "TIKTOK_CLIENT_SECRET": "set" if os.getenv("TIKTOK_CLIENT_SECRET") else "missing",
+        "TIKTOK_ACCESS_TOKEN": "set" if os.getenv("TIKTOK_ACCESS_TOKEN") else "missing",
+        "YOUTUBE_CLIENT_ID": os.getenv("YOUTUBE_CLIENT_ID") or os.getenv("GOOGLE_CLIENT_ID") or "—",
+        "YOUTUBE_CLIENT_SECRET": "set" if (os.getenv("YOUTUBE_CLIENT_SECRET") or os.getenv("GOOGLE_CLIENT_SECRET")) else "missing",
+        "YOUTUBE_ACCESS_TOKEN": "set" if os.getenv("YOUTUBE_ACCESS_TOKEN") else "missing",
+        "YOUTUBE_REFRESH_TOKEN": "set" if os.getenv("YOUTUBE_REFRESH_TOKEN") else "missing",
     }
-    return templates.TemplateResponse(
-        request,
-        "settings.html",
-        {"accounts": accounts, "env": env_summary, "stats": db.stats()},
-    )
+    ctx = _base_context("settings")
+    ctx.update({"accounts": accounts, "env": env_summary})
+    return templates.TemplateResponse(request, "settings.html", ctx)
 
 
 @app.post("/settings/test/{platform}", response_class=HTMLResponse)
@@ -374,6 +909,22 @@ async def test_connection(request: Request, platform: str):
         info = _safe_threads_info()
         connected = bool(info.get("connected"))
         message = f"@{info.get('username')}" if connected else info.get("error", "Not linked")
+    elif platform == "linkedin":
+        info = _safe_linkedin_info()
+        connected = bool(info.get("connected"))
+        message = info.get("name", "OK") if connected else info.get("error", "Not linked")
+    elif platform == "tiktok":
+        info = _safe_tiktok_info()
+        connected = bool(info.get("connected"))
+        message = (
+            f"@{info.get('username')}" if connected and info.get("username")
+            else info.get("name", "OK") if connected
+            else info.get("error", "Not linked")
+        )
+    elif platform == "youtube":
+        info = _safe_youtube_info()
+        connected = bool(info.get("connected"))
+        message = info.get("name", "OK") if connected else info.get("error", "Not linked")
     else:
         connected, message = False, "Adapter not implemented"
     response = HTMLResponse(
@@ -391,15 +942,82 @@ async def test_connection(request: Request, platform: str):
 
 
 # ---------------------------------------------------------------------------
+# Scheduler routes
+# ---------------------------------------------------------------------------
+
+@app.post("/schedule/{post_id}", response_class=HTMLResponse)
+async def schedule_post(request: Request, post_id: int, at: str = Form("")):
+    """Schedule a pending post for future publication."""
+    from datetime import datetime, timezone as tz
+
+    post = db.get_post(post_id)
+    if not post:
+        raise HTTPException(404)
+    if post["status"] not in ("pending", "scheduled"):
+        raise HTTPException(409, f"Post is {post['status']}, cannot schedule")
+
+    at = at.strip()
+    if not at:
+        raise HTTPException(400, "Missing 'at' — provide an ISO-8601 datetime")
+
+    try:
+        run_at = datetime.fromisoformat(at.replace("Z", "+00:00"))
+        if run_at.tzinfo is None:
+            run_at = run_at.replace(tzinfo=tz.utc)
+    except ValueError:
+        raise HTTPException(400, f"Bad datetime: {at}")
+
+    if run_at <= datetime.now(tz.utc):
+        raise HTTPException(400, "Scheduled time must be in the future")
+
+    scheduler.schedule_post(post_id, run_at)
+    return _refresh_all(
+        request,
+        toast=("success", f"Scheduled post #{post_id} for {run_at:%Y-%m-%d %H:%M} UTC"),
+    )
+
+
+@app.post("/unschedule/{post_id}", response_class=HTMLResponse)
+async def unschedule_post(request: Request, post_id: int):
+    """Cancel a scheduled post and return it to pending."""
+    post = db.get_post(post_id)
+    if not post:
+        raise HTTPException(404)
+    if post["status"] != "scheduled":
+        raise HTTPException(409, f"Post is {post['status']}, not scheduled")
+
+    removed = scheduler.cancel_post(post_id)
+    if removed:
+        toast = ("info", f"Post #{post_id} unscheduled — back to pending")
+    else:
+        toast = ("warning", f"Post #{post_id} job not found, reset to pending")
+    return _refresh_all(request, toast=toast)
+
+
+@app.get("/schedules", response_class=HTMLResponse)
+async def list_schedules(request: Request):
+    """Return all scheduled posts + active APScheduler jobs."""
+    scheduled = db.list_scheduled()
+    jobs = scheduler.list_jobs()
+    return templates.TemplateResponse(
+        request,
+        "_schedules.html",
+        {"scheduled": scheduled, "jobs": jobs},
+    )
+
+
+# ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
 
 def _refresh_all(request: Request, toast: tuple[str, str] | None = None) -> HTMLResponse:
+    pending_singles, pending_groups = db.list_pending_grouped()
     response = templates.TemplateResponse(
         request,
         "_columns.html",
         {
-            "pending": db.list_posts(status="pending"),
+            "pending": pending_singles,
+            "pending_groups": pending_groups,
             "published": db.list_posts(status="published", limit=10),
             "failed": db.list_posts(status="failed", limit=5),
             "rejected": db.list_posts(status="rejected", limit=5),
@@ -413,15 +1031,21 @@ def _refresh_all(request: Request, toast: tuple[str, str] | None = None) -> HTML
 
 
 def _safe_page_info() -> dict:
-    """Best-effort page info; never crashes the dashboard if the API is unhappy."""
+    """Lookup Facebook page info; safe fallback when token is missing/expired.
+
+    Returns the API result with `connected=True` on success, or a dict with
+    `connected=False` and an error string when the call fails. Other helpers
+    in this module follow the same shape.
+    """
     try:
-        info = fb.get_page_info() if hasattr(fb, "get_page_info") else {}
-        if isinstance(info, dict) and "name" in info:
-            return info
-    except Exception:
-        pass
-    page_id = os.getenv("FACEBOOK_PAGE_ID", "?")
-    return {"id": page_id, "name": "Hack-Tech", "category": "Education website"}
+        info = fb.get_page_info() if hasattr(fb, "get_page_info") else None
+    except Exception as exc:
+        return {"connected": False, "error": str(exc)}
+    if isinstance(info, dict) and info.get("id") and info.get("name"):
+        # Mark explicitly connected so consumers don't have to infer
+        info = {**info, "connected": True}
+        return info
+    return {"connected": False, "error": "Facebook page check returned no name/id"}
 
 
 def _safe_ig_info() -> dict:
@@ -446,6 +1070,33 @@ def _safe_threads_info() -> dict:
     """Lookup Threads account; safe fallback when token is missing/expired."""
     try:
         info = fb.get_threads_account_info()
+        return info if isinstance(info, dict) else {"connected": False}
+    except Exception as exc:
+        return {"connected": False, "error": str(exc)}
+
+
+def _safe_linkedin_info() -> dict:
+    """Lookup LinkedIn profile; safe fallback when token is missing/expired."""
+    try:
+        info = fb.get_linkedin_profile()
+        return info if isinstance(info, dict) else {"connected": False}
+    except Exception as exc:
+        return {"connected": False, "error": str(exc)}
+
+
+def _safe_tiktok_info() -> dict:
+    """Lookup TikTok profile; safe fallback when token is missing/expired."""
+    try:
+        info = fb.get_tiktok_profile()
+        return info if isinstance(info, dict) else {"connected": False}
+    except Exception as exc:
+        return {"connected": False, "error": str(exc)}
+
+
+def _safe_youtube_info() -> dict:
+    """Lookup YouTube channel info; safe fallback when token is missing/expired."""
+    try:
+        info = fb.get_youtube_channel_info()
         return info if isinstance(info, dict) else {"connected": False}
     except Exception as exc:
         return {"connected": False, "error": str(exc)}

--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -638,35 +638,67 @@ def _store_tokens(updates: dict[str, str]) -> None:
 def _public_redirect_uri(request: Request, platform: str) -> str:
     """Compute the OAuth callback URL for a given platform.
 
-    Uses the request's host so localhost or a tunnelled HTTPS host both work
-    without configuration.
+    Default: derive from the request's base URL so localhost works without
+    any configuration.
+
+    Override: set OAUTH_REDIRECT_BASE_URL in the environment when the
+    dashboard runs behind a reverse proxy or tunnel and the redirect URI
+    needs to match exactly what was registered in the platform dev portal.
+    Example value: "https://yourdomain.com" (no trailing slash).
     """
-    base = str(request.base_url).rstrip("/")
+    override = os.getenv("OAUTH_REDIRECT_BASE_URL", "").rstrip("/")
+    base = override or str(request.base_url).rstrip("/")
     return f"{base}/oauth/{platform}/callback"
+
+
+def _verify_oauth_state(request: Request, cookie_name: str, supplied_state: str) -> None:
+    """Reject the callback when the state cookie is missing or doesn't match.
+
+    Prevents CSRF: an attacker cannot trick a logged-in user into accepting
+    OAuth credentials they did not start. The cookie is set during /start
+    and removed after the callback runs.
+    """
+    expected = request.cookies.get(cookie_name)
+    if not expected:
+        raise HTTPException(
+            400,
+            "OAuth flow not properly initiated (no state cookie). "
+            "Start the connection from the Settings page.",
+        )
+    if not supplied_state or supplied_state != expected:
+        raise HTTPException(400, "OAuth state mismatch")
 
 
 @app.get("/oauth/linkedin/start")
 async def oauth_linkedin_start(request: Request):
     """Kick off the LinkedIn OAuth dance."""
     redirect_uri = _public_redirect_uri(request, "linkedin")
-    url = fb.linkedin.get_auth_url(redirect_uri)
-    return RedirectResponse(url=url, status_code=303)
+    state = secrets.token_urlsafe(16)
+    url = fb.linkedin.get_auth_url(redirect_uri) + f"&state={state}"
+    response = RedirectResponse(url=url, status_code=303)
+    response.set_cookie("linkedin_oauth_state", state, max_age=600, httponly=True, samesite="lax")
+    return response
 
 
 @app.get("/oauth/linkedin/callback")
-async def oauth_linkedin_callback(request: Request, code: str = "", error: str = ""):
+async def oauth_linkedin_callback(
+    request: Request, code: str = "", state: str = "", error: str = ""
+):
     """Receive ?code= from LinkedIn, exchange for token, store, redirect."""
     if error:
         raise HTTPException(400, f"LinkedIn auth error: {error}")
     if not code:
         raise HTTPException(400, "Missing ?code parameter")
+    _verify_oauth_state(request, "linkedin_oauth_state", state)
     redirect_uri = _public_redirect_uri(request, "linkedin")
     result = fb.linkedin.exchange_code(code, redirect_uri)
     token = result.get("access_token")
     if not token:
         raise HTTPException(400, f"Token exchange failed: {result}")
     _store_tokens({"LINKEDIN_ACCESS_TOKEN": token})
-    return RedirectResponse(url="/settings", status_code=303)
+    response = RedirectResponse(url="/settings", status_code=303)
+    response.delete_cookie("linkedin_oauth_state")
+    return response
 
 
 @app.get("/oauth/tiktok/start")
@@ -691,9 +723,7 @@ async def oauth_tiktok_callback(
         raise HTTPException(400, f"TikTok auth error: {error}")
     if not code:
         raise HTTPException(400, "Missing ?code parameter")
-    expected = request.cookies.get("tiktok_oauth_state")
-    if expected and state and state != expected:
-        raise HTTPException(400, "TikTok OAuth state mismatch")
+    _verify_oauth_state(request, "tiktok_oauth_state", state)
     redirect_uri = _public_redirect_uri(request, "tiktok")
     result = fb.tiktok.exchange_code(code, redirect_uri)
     token = result.get("access_token")
@@ -731,9 +761,7 @@ async def oauth_youtube_callback(
         raise HTTPException(400, f"YouTube auth error: {error}")
     if not code:
         raise HTTPException(400, "Missing ?code parameter")
-    expected = request.cookies.get("youtube_oauth_state")
-    if expected and state and state != expected:
-        raise HTTPException(400, "YouTube OAuth state mismatch")
+    _verify_oauth_state(request, "youtube_oauth_state", state)
     redirect_uri = _public_redirect_uri(request, "youtube")
     result = fb.youtube.exchange_code(code, redirect_uri)
     token = result.get("access_token")

--- a/dashboard/auth.py
+++ b/dashboard/auth.py
@@ -1,0 +1,140 @@
+"""Simple cookie-based authentication for the dashboard.
+
+If the env var DASHBOARD_PASSWORD is set, all routes (except /login, /static,
+/favicon.ico) require a valid session cookie.  When it is *not* set the auth
+layer is transparent and every request passes through.
+
+Cookie signing uses hmac+hashlib (zero extra dependencies).
+"""
+from __future__ import annotations
+
+import hashlib
+import hmac
+import os
+import secrets
+import time
+
+from fastapi import Request
+from fastapi.responses import RedirectResponse
+from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
+from starlette.responses import Response
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+COOKIE_NAME = "sae_session"
+SESSION_MAX_AGE = 60 * 60 * 24  # 24 hours
+
+# Paths that never require auth
+PUBLIC_PATHS: set[str] = {"/login", "/logout", "/favicon.ico"}
+PUBLIC_PREFIXES: tuple[str, ...] = ("/static/",)
+
+
+def _get_secret_key() -> str:
+    """Return a stable secret key for cookie signing.
+
+    Uses DASHBOARD_SECRET_KEY if set, otherwise generates a random one at
+    import time.  (A random key means sessions don't survive server restarts,
+    which is fine for a localhost tool.)
+    """
+    key = os.getenv("DASHBOARD_SECRET_KEY", "")
+    if key:
+        return key
+    return secrets.token_hex(32)
+
+
+SECRET_KEY = _get_secret_key()
+
+
+# ---------------------------------------------------------------------------
+# Cookie helpers (hmac + hashlib, zero dependencies)
+# ---------------------------------------------------------------------------
+
+def _sign(payload: str) -> str:
+    """Return ``payload.signature`` where signature = HMAC-SHA256."""
+    sig = hmac.new(SECRET_KEY.encode(), payload.encode(), hashlib.sha256).hexdigest()
+    return f"{payload}.{sig}"
+
+
+def _verify(token: str) -> str | None:
+    """Verify a signed token.  Returns the payload on success, None on failure."""
+    if "." not in token:
+        return None
+    payload, sig = token.rsplit(".", 1)
+    expected = hmac.new(SECRET_KEY.encode(), payload.encode(), hashlib.sha256).hexdigest()
+    if not hmac.compare_digest(sig, expected):
+        return None
+    return payload
+
+
+def create_session_token() -> str:
+    """Create a signed session token embedding the current timestamp."""
+    ts = str(int(time.time()))
+    return _sign(ts)
+
+
+def validate_session_token(token: str) -> bool:
+    """Check that *token* is validly signed and not expired."""
+    payload = _verify(token)
+    if payload is None:
+        return False
+    try:
+        ts = int(payload)
+    except ValueError:
+        return False
+    return (time.time() - ts) < SESSION_MAX_AGE
+
+
+# ---------------------------------------------------------------------------
+# Auth check (password)
+# ---------------------------------------------------------------------------
+
+def check_password(password: str) -> bool:
+    """Compare *password* against the env var DASHBOARD_PASSWORD."""
+    expected = os.getenv("DASHBOARD_PASSWORD", "")
+    if not expected:
+        return False
+    return hmac.compare_digest(password.encode(), expected.encode())
+
+
+def auth_required() -> bool:
+    """Return True when the dashboard should enforce authentication."""
+    return bool(os.getenv("DASHBOARD_PASSWORD", ""))
+
+
+# ---------------------------------------------------------------------------
+# Middleware
+# ---------------------------------------------------------------------------
+
+def _is_public(path: str) -> bool:
+    """Return True if *path* should skip auth."""
+    if path in PUBLIC_PATHS:
+        return True
+    for prefix in PUBLIC_PREFIXES:
+        if path.startswith(prefix):
+            return True
+    return False
+
+
+class AuthMiddleware(BaseHTTPMiddleware):
+    """Redirect unauthenticated users to /login.
+
+    Completely transparent when DASHBOARD_PASSWORD is not set.
+    """
+
+    async def dispatch(
+        self, request: Request, call_next: RequestResponseEndpoint
+    ) -> Response:
+        if not auth_required():
+            return await call_next(request)
+
+        if _is_public(request.url.path):
+            return await call_next(request)
+
+        token = request.cookies.get(COOKIE_NAME)
+        if token and validate_session_token(token):
+            return await call_next(request)
+
+        # Unauthenticated -- redirect to login
+        return RedirectResponse(url="/login", status_code=303)

--- a/dashboard/db.py
+++ b/dashboard/db.py
@@ -28,7 +28,8 @@ CREATE TABLE IF NOT EXISTS post (
     created_at      TEXT DEFAULT CURRENT_TIMESTAMP,
     decided_at      TEXT,
     published_at    TEXT,
-    permalink_url   TEXT
+    permalink_url   TEXT,
+    group_id        TEXT
 );
 
 CREATE INDEX IF NOT EXISTS idx_post_status ON post(status);
@@ -50,6 +51,12 @@ def init_db():
             conn.execute("ALTER TABLE post ADD COLUMN recipient TEXT")
         if "template_name" not in cols:
             conn.execute("ALTER TABLE post ADD COLUMN template_name TEXT")
+        if "scheduled_for" not in cols:
+            conn.execute("ALTER TABLE post ADD COLUMN scheduled_for TEXT")
+        if "group_id" not in cols:
+            conn.execute("ALTER TABLE post ADD COLUMN group_id TEXT")
+        # Always ensure the index exists (idempotent, runs after the column is present)
+        conn.execute("CREATE INDEX IF NOT EXISTS idx_post_group ON post(group_id)")
         conn.commit()
 
 
@@ -70,17 +77,98 @@ def create_post(
     image_url: str | None = None,
     recipient: str | None = None,
     template_name: str | None = None,
+    group_id: str | None = None,
 ) -> int:
     """Insert a new pending post. Returns the post id."""
     with connect() as conn:
         cur = conn.execute(
             "INSERT INTO post (message, account_name, platform, image_url, "
-            "recipient, template_name, status) "
-            "VALUES (?, ?, ?, ?, ?, ?, 'pending')",
-            (message, account_name, platform, image_url, recipient, template_name),
+            "recipient, template_name, status, group_id) "
+            "VALUES (?, ?, ?, ?, ?, ?, 'pending', ?)",
+            (message, account_name, platform, image_url, recipient, template_name, group_id),
         )
         conn.commit()
         return cur.lastrowid
+
+
+def create_broadcast(
+    message: str,
+    targets: list[dict],
+    image_url: str | None = None,
+) -> dict:
+    """Create N pending posts under one group_id, one per platform target.
+
+    Each target dict carries: platform, account_name, optional message_override.
+    Returns {"group_id": str, "post_ids": list[int]}.
+    """
+    import uuid
+
+    if not targets:
+        raise ValueError("Broadcast needs at least one target")
+    group_id = str(uuid.uuid4())
+    post_ids: list[int] = []
+    with connect() as conn:
+        for target in targets:
+            text = target.get("message_override") or message
+            cur = conn.execute(
+                "INSERT INTO post (message, account_name, platform, image_url, "
+                "status, group_id) "
+                "VALUES (?, ?, ?, ?, 'pending', ?)",
+                (
+                    text,
+                    target.get("account_name", target["platform"].title()),
+                    target["platform"],
+                    image_url,
+                    group_id,
+                ),
+            )
+            post_ids.append(cur.lastrowid)
+        conn.commit()
+    return {"group_id": group_id, "post_ids": post_ids}
+
+
+def list_group(group_id: str, status: str | None = None) -> list[dict]:
+    """Return every post sharing a group_id, optionally filtered by status."""
+    with connect() as conn:
+        if status:
+            rows = conn.execute(
+                "SELECT * FROM post WHERE group_id = ? AND status = ? "
+                "ORDER BY id ASC",
+                (group_id, status),
+            ).fetchall()
+        else:
+            rows = conn.execute(
+                "SELECT * FROM post WHERE group_id = ? ORDER BY id ASC",
+                (group_id,),
+            ).fetchall()
+        return [dict(r) for r in rows]
+
+
+def list_pending_grouped() -> tuple[list[dict], list[list[dict]]]:
+    """Return (singles, groups) for the pending queue.
+
+    singles: pending posts with NULL group_id, rendered individually.
+    groups: list of platform-row lists, one entry per group_id, ordered newest first.
+    """
+    with connect() as conn:
+        rows = conn.execute(
+            "SELECT * FROM post WHERE status = 'pending' "
+            "ORDER BY created_at DESC"
+        ).fetchall()
+    singles: list[dict] = []
+    grouped: dict[str, list[dict]] = {}
+    group_order: list[str] = []
+    for r in rows:
+        d = dict(r)
+        gid = d.get("group_id")
+        if not gid:
+            singles.append(d)
+        else:
+            if gid not in grouped:
+                grouped[gid] = []
+                group_order.append(gid)
+            grouped[gid].append(d)
+    return singles, [grouped[g] for g in group_order]
 
 
 def get_post(post_id: int):
@@ -146,6 +234,31 @@ def _now() -> str:
     from datetime import datetime, timezone
 
     return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+def list_scheduled(limit: int = 50):
+    """Return all posts with status='scheduled', ordered by scheduled time."""
+    with connect() as conn:
+        rows = conn.execute(
+            "SELECT * FROM post WHERE status = 'scheduled' "
+            "ORDER BY scheduled_for ASC LIMIT ?",
+            (limit,),
+        ).fetchall()
+        return [dict(r) for r in rows]
+
+
+def calendar_posts(start_iso: str, end_iso: str):
+    """Return all posts (any status) within a date range for the calendar view."""
+    with connect() as conn:
+        rows = conn.execute(
+            "SELECT * FROM post WHERE "
+            "(scheduled_for BETWEEN ? AND ?) OR "
+            "(published_at BETWEEN ? AND ?) OR "
+            "(created_at BETWEEN ? AND ?) "
+            "ORDER BY COALESCE(scheduled_for, published_at, created_at) ASC",
+            (start_iso, end_iso, start_iso, end_iso, start_iso, end_iso),
+        ).fetchall()
+        return [dict(r) for r in rows]
 
 
 def stats():

--- a/dashboard/db.py
+++ b/dashboard/db.py
@@ -3,7 +3,6 @@
 Single-file storage at ~/.social-auto-engine/dashboard.db. WAL mode for
 concurrent reads from FastAPI workers + the MCP server.
 """
-import os
 import sqlite3
 from contextlib import contextmanager
 from pathlib import Path

--- a/dashboard/scheduler.py
+++ b/dashboard/scheduler.py
@@ -1,0 +1,166 @@
+"""APScheduler integration — schedule posts to publish at a future time.
+
+Uses the existing dashboard DB and Manager for publishing. APScheduler
+stores its own job metadata in a separate SQLite file so it never
+collides with the post table.
+
+Usage:
+    from dashboard import scheduler
+    scheduler.start()                         # call once at app boot
+    scheduler.schedule_post(post_id, run_at)  # queue a post
+    scheduler.cancel_post(post_id)            # cancel before it fires
+    scheduler.list_jobs()                     # see what's pending
+    scheduler.shutdown()                      # clean stop
+"""
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Optional
+
+from apscheduler.jobstores.sqlalchemy import SQLAlchemyJobStore
+from apscheduler.schedulers.background import BackgroundScheduler
+
+from . import db
+
+log = logging.getLogger("social-engine.scheduler")
+
+# Job metadata lives in its own file — never touches dashboard.db
+JOBS_DIR = Path.home() / ".social-auto-engine"
+JOBS_DIR.mkdir(parents=True, exist_ok=True)
+JOBS_DB = JOBS_DIR / "scheduler_jobs.db"
+
+_scheduler: Optional[BackgroundScheduler] = None
+
+
+def get_scheduler() -> BackgroundScheduler:
+    """Lazy-init the scheduler singleton."""
+    global _scheduler
+    if _scheduler is None:
+        _scheduler = BackgroundScheduler(
+            jobstores={
+                "default": SQLAlchemyJobStore(
+                    url=f"sqlite:///{JOBS_DB.as_posix()}"
+                )
+            },
+            timezone=timezone.utc,
+        )
+    return _scheduler
+
+
+def start() -> None:
+    """Start the scheduler. Safe to call multiple times."""
+    s = get_scheduler()
+    if not s.running:
+        s.start()
+        log.info("Scheduler started — jobs_db=%s", JOBS_DB)
+
+
+def shutdown(wait: bool = False) -> None:
+    """Stop the scheduler gracefully."""
+    s = get_scheduler()
+    if s.running:
+        s.shutdown(wait=wait)
+        log.info("Scheduler stopped")
+
+
+# ---------------------------------------------------------------------------
+# Job function — this is what APScheduler calls when a post is due
+# ---------------------------------------------------------------------------
+
+def _publish_scheduled_post(post_id: int) -> None:
+    """Called by APScheduler when a scheduled post's time arrives.
+
+    Imports the publish function from app.py to reuse the exact same
+    publishing logic (platform dispatch, error handling, DB updates).
+    """
+    post = db.get_post(post_id)
+    if not post:
+        log.warning("Scheduled post #%s not found — skipping", post_id)
+        return
+
+    if post["status"] != "scheduled":
+        log.info(
+            "Post #%s is '%s', not 'scheduled' — skipping",
+            post_id, post["status"],
+        )
+        return
+
+    # Mark as pending so the publish function can process it
+    db.update_post(post_id, status="pending")
+
+    # Import here to avoid circular imports
+    from .app import _publish_post
+
+    _publish_post(post)
+    refreshed = db.get_post(post_id)
+    status = refreshed["status"] if refreshed else "unknown"
+    log.info("Scheduled post #%s → %s", post_id, status)
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+def schedule_post(post_id: int, run_at: datetime) -> str:
+    """Schedule a post to publish at a specific time. Returns the job ID."""
+    s = get_scheduler()
+    job_id = f"post-{post_id}"
+
+    # Ensure run_at is UTC-aware
+    if run_at.tzinfo is None:
+        run_at = run_at.replace(tzinfo=timezone.utc)
+
+    s.add_job(
+        _publish_scheduled_post,
+        trigger="date",
+        run_date=run_at,
+        args=[post_id],
+        id=job_id,
+        replace_existing=True,
+        misfire_grace_time=300,  # 5 min grace for missed jobs
+    )
+
+    # Update the post record
+    db.update_post(
+        post_id,
+        status="scheduled",
+        scheduled_for=run_at.isoformat(),
+    )
+
+    log.info("Post #%s scheduled for %s (job=%s)", post_id, run_at, job_id)
+    return job_id
+
+
+def cancel_post(post_id: int) -> bool:
+    """Cancel a scheduled post. Returns True if the job was found and removed."""
+    s = get_scheduler()
+    job_id = f"post-{post_id}"
+    try:
+        s.remove_job(job_id)
+        db.update_post(
+            post_id,
+            status="pending",
+            scheduled_for=None,
+        )
+        log.info("Cancelled scheduled post #%s", post_id)
+        return True
+    except Exception as e:
+        log.info("Cancel post #%s: job not found (%s)", post_id, e)
+        return False
+
+
+def list_jobs() -> list[dict]:
+    """Return all pending scheduled jobs."""
+    s = get_scheduler()
+    return [
+        {
+            "id": j.id,
+            "post_id": j.args[0] if j.args else None,
+            "next_run_time": (
+                j.next_run_time.isoformat() if j.next_run_time else None
+            ),
+        }
+        for j in s.get_jobs()
+    ]

--- a/dashboard/static/styles.css
+++ b/dashboard/static/styles.css
@@ -1,95 +1,83 @@
-/* Social Auto Engine — Professional dark mode dashboard
-   Linear / Vercel / Resend reference. Restrained color, tight spacing, refined typography.
+/* Social Auto Engine — Clean dark dashboard
+   Inspired by Linear / Vercel / Resend. Restrained color, tight spacing.
 */
 
 :root {
-  /* Surfaces — true blacks with subtle elevation */
+  /* Surfaces */
   --bg: #0a0a0a;
   --bg-sidebar: #0f0f0f;
   --bg-elevated: #141414;
   --bg-hover: #1a1a1a;
   --bg-active: #1f1f1f;
 
-  /* Borders — barely there */
+  /* Borders */
   --border: rgba(255, 255, 255, 0.06);
   --border-strong: rgba(255, 255, 255, 0.1);
   --border-active: rgba(255, 255, 255, 0.18);
 
-  /* Text — opacity-driven hierarchy */
+  /* Text */
   --text: rgba(255, 255, 255, 0.96);
   --text-secondary: rgba(255, 255, 255, 0.62);
   --text-tertiary: rgba(255, 255, 255, 0.42);
   --text-quaternary: rgba(255, 255, 255, 0.24);
 
-  /* Accent — single hue, used sparingly */
+  /* Accent */
   --accent: #7b61ff;
   --accent-hover: #8d75ff;
   --accent-bg: rgba(123, 97, 255, 0.1);
   --accent-bg-strong: rgba(123, 97, 255, 0.18);
   --accent-border: rgba(123, 97, 255, 0.3);
 
-  /* Status colors — used as 6px dots, never as fills */
+  /* Status */
   --status-pending: #eab308;
   --status-success: #22c55e;
   --status-error: #ef4444;
   --status-neutral: rgba(255, 255, 255, 0.32);
 
-  /* Brand gradient — only on logo + primary CTA */
+  /* Brand gradient */
   --gradient: linear-gradient(135deg, #00d4ff 0%, #7b61ff 50%, #ff4d8d 100%);
 
-  /* Spacing system (4pt) */
-  --sp-1: 4px;
-  --sp-2: 8px;
-  --sp-3: 12px;
-  --sp-4: 16px;
-  --sp-5: 20px;
-  --sp-6: 24px;
-  --sp-8: 32px;
-  --sp-10: 40px;
-  --sp-12: 48px;
+  /* Spacing (4pt) */
+  --sp-1: 4px; --sp-2: 8px; --sp-3: 12px; --sp-4: 16px;
+  --sp-5: 20px; --sp-6: 24px; --sp-8: 32px; --sp-10: 40px; --sp-12: 48px;
 
   /* Radii */
-  --r-sm: 6px;
-  --r: 8px;
-  --r-md: 10px;
-  --r-lg: 12px;
+  --r-sm: 6px; --r: 8px; --r-md: 10px; --r-lg: 12px;
 
   /* Typography */
   --font-sans: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
   --font-mono: 'JetBrains Mono', 'Fira Code', ui-monospace, monospace;
 
   /* Layout */
-  --sidebar-w: 232px;
-  --header-h: 52px;
+  --sidebar-w: 220px;
+  --header-h: 48px;
 }
 
 *, ::before, ::after { box-sizing: border-box; }
 
 html, body {
-  margin: 0;
-  padding: 0;
+  margin: 0; padding: 0;
   background: var(--bg);
   color: var(--text);
   font-family: var(--font-sans);
-  font-size: 14px;
+  font-size: 13.5px;
   line-height: 1.5;
   font-feature-settings: 'cv02', 'cv03', 'cv04', 'cv11';
   -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
 }
 
 button, input, textarea, select { font-family: inherit; }
 button { cursor: pointer; border: none; background: transparent; color: inherit; }
 a { color: inherit; text-decoration: none; }
 
-/* ─── App shell ────────────────────────────────────────── */
+/* ─── App shell ──────────────────────────────── */
 .app {
   display: grid;
   grid-template-columns: var(--sidebar-w) 1fr;
   min-height: 100vh;
 }
 
-/* ─── Sidebar ──────────────────────────────────────────── */
+/* ─── Sidebar ────────────────────────────────── */
 .sidebar {
   background: var(--bg-sidebar);
   border-right: 1px solid var(--border);
@@ -98,82 +86,90 @@ a { color: inherit; text-decoration: none; }
   position: sticky;
   top: 0;
   height: 100vh;
+  overflow-y: auto;
 }
 
 .sidebar-brand {
-  padding: var(--sp-4) var(--sp-5);
+  padding: var(--sp-3) var(--sp-4);
   display: flex;
   align-items: center;
-  gap: var(--sp-3);
   height: var(--header-h);
   border-bottom: 1px solid var(--border);
 }
 
 .brand-mark {
-  width: 24px;
-  height: 24px;
-  border-radius: 6px;
+  width: 22px; height: 22px;
+  border-radius: 5px;
   background: var(--gradient);
-  display: grid;
-  place-items: center;
+  display: grid; place-items: center;
   color: #fff;
   font-weight: 800;
-  font-size: 9.5px;
+  font-size: 8.5px;
   letter-spacing: 0.5px;
   flex-shrink: 0;
 }
 
 .brand-text {
-  font-size: 13.5px;
+  font-size: 13px;
   font-weight: 600;
   letter-spacing: -0.2px;
 }
 
 .sidebar-section {
-  padding: var(--sp-4) var(--sp-3) var(--sp-2);
+  padding: var(--sp-3) var(--sp-2) var(--sp-1);
 }
 
 .sidebar-section-label {
-  font-size: 10.5px;
+  font-size: 10px;
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.6px;
   color: var(--text-tertiary);
   padding: 0 var(--sp-2);
-  margin-bottom: var(--sp-2);
+  margin-bottom: var(--sp-1);
 }
 
 .nav-item {
   display: flex;
   align-items: center;
   gap: var(--sp-2);
-  padding: 6px var(--sp-2);
+  padding: 5px var(--sp-2);
   border-radius: var(--r-sm);
-  font-size: 13px;
+  font-size: 12.5px;
   font-weight: 500;
   color: var(--text-secondary);
-  transition: background 100ms, color 100ms;
+  transition: background 80ms, color 80ms;
   cursor: pointer;
+  position: relative;
 }
 
 .nav-item:hover { background: var(--bg-hover); color: var(--text); }
 .nav-item.active { background: var(--bg-active); color: var(--text); }
 
+.nav-item.active::before {
+  content: '';
+  position: absolute;
+  left: -8px; top: 50%;
+  transform: translateY(-50%);
+  width: 3px; height: 14px;
+  border-radius: 0 3px 3px 0;
+  background: var(--accent);
+}
+
 .nav-item svg {
-  width: 14px;
-  height: 14px;
+  width: 14px; height: 14px;
   flex-shrink: 0;
   stroke-width: 1.75;
-  opacity: 0.85;
+  opacity: 0.75;
 }
 
 .nav-item .badge {
   margin-left: auto;
-  font-size: 10.5px;
+  font-size: 10px;
   font-family: var(--font-mono);
   background: var(--bg-elevated);
   border: 1px solid var(--border);
-  padding: 1px 6px;
+  padding: 0 5px;
   border-radius: 4px;
   color: var(--text-secondary);
 }
@@ -182,52 +178,80 @@ a { color: inherit; text-decoration: none; }
   display: flex;
   align-items: center;
   gap: var(--sp-2);
-  padding: 6px var(--sp-2);
+  padding: 4px var(--sp-2);
   border-radius: var(--r-sm);
-  font-size: 13px;
-  color: var(--text-secondary);
-  cursor: pointer;
-  transition: background 100ms;
+  font-size: 12px;
+  color: var(--text-tertiary);
+  transition: background 80ms;
 }
 
-.nav-account:hover { background: var(--bg-hover); }
+.nav-account:hover { background: var(--bg-hover); color: var(--text-secondary); }
 
 .platform-icon {
-  width: 18px;
-  height: 18px;
-  border-radius: 4px;
-  display: grid;
-  place-items: center;
-  font-size: 9px;
-  font-weight: 700;
-  color: #fff;
-  flex-shrink: 0;
+  width: 16px; height: 16px;
+  border-radius: 3px;
+  display: grid; place-items: center;
+  font-size: 8px; font-weight: 700;
+  color: #fff; flex-shrink: 0;
 }
 .platform-icon.fb { background: #1877F2; }
 .platform-icon.ig { background: linear-gradient(45deg, #f09433, #e6683c, #dc2743, #cc2366, #bc1888); }
 .platform-icon.li { background: #0A66C2; }
 .platform-icon.x  { background: #000; border: 1px solid var(--border-strong); }
 .platform-icon.tt { background: #000; }
-.platform-icon.wa { background: #25D366; color: #fff; font-weight: 800; }
-.platform-icon.th { background: #000; border: 1px solid var(--border-strong); font-weight: 800; font-size: 10px; }
+.platform-icon.yt { background: #FF0000; }
+.platform-icon.wa { background: #25D366; font-weight: 800; }
+.platform-icon.th { background: #000; border: 1px solid var(--border-strong); font-weight: 800; font-size: 9px; }
+
+.sidebar-company {
+  margin: 0 0 var(--sp-1);
+}
+.sidebar-company > summary {
+  list-style: none;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 4px var(--sp-2);
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--text-tertiary);
+  border-radius: var(--r-sm);
+}
+.sidebar-company > summary::-webkit-details-marker { display: none; }
+.sidebar-company > summary:hover { background: var(--bg-hover); color: var(--text-secondary); }
+.sidebar-company .company-chevron {
+  transition: transform 120ms;
+  opacity: 0.6;
+}
+.sidebar-company[open] .company-chevron {
+  transform: rotate(180deg);
+}
+.sidebar-company-body {
+  padding: 2px 0 4px;
+}
 
 .nav-account .status-dot {
   margin-left: auto;
-  width: 6px;
-  height: 6px;
+  width: 5px; height: 5px;
   border-radius: 50%;
   background: var(--status-neutral);
   flex-shrink: 0;
 }
-.nav-account.connected .status-dot { background: var(--status-success); box-shadow: 0 0 0 3px rgba(34, 197, 94, 0.15); }
+.nav-account.connected .status-dot {
+  background: var(--status-success);
+  box-shadow: 0 0 0 2px rgba(34, 197, 94, 0.15);
+}
 
 .sidebar-footer {
   margin-top: auto;
-  padding: var(--sp-3);
+  padding: var(--sp-2);
   border-top: 1px solid var(--border);
 }
 
-/* ─── Main area ────────────────────────────────────────── */
+/* ─── Main area ──────────────────────────────── */
 .main {
   display: flex;
   flex-direction: column;
@@ -237,41 +261,36 @@ a { color: inherit; text-decoration: none; }
 .topbar {
   height: var(--header-h);
   border-bottom: 1px solid var(--border);
-  padding: 0 var(--sp-8);
+  padding: 0 var(--sp-6);
   display: flex;
   align-items: center;
   justify-content: space-between;
   background: rgba(10, 10, 10, 0.85);
   backdrop-filter: blur(8px);
-  -webkit-backdrop-filter: blur(8px);
   position: sticky;
   top: 0;
   z-index: 50;
-  /* needed for ::after gradient line */
-  position: sticky;
+}
+
+.topbar::after {
+  content: '';
+  position: absolute;
+  bottom: 0; left: 0; right: 0;
+  height: 1px;
+  background: linear-gradient(90deg, transparent, var(--border-strong) 20%, var(--accent-border) 50%, var(--border-strong) 80%, transparent);
+  opacity: 0.5;
 }
 
 .breadcrumb {
   display: flex;
   align-items: center;
   gap: var(--sp-2);
-  font-size: 13px;
+  font-size: 12.5px;
 }
 
-.breadcrumb-sep {
-  color: var(--text-quaternary);
-  font-size: 11px;
-}
-
-.breadcrumb-current {
-  color: var(--text);
-  font-weight: 500;
-}
-
-.breadcrumb-link {
-  color: var(--text-secondary);
-  cursor: pointer;
-}
+.breadcrumb-sep { color: var(--text-quaternary); font-size: 10px; }
+.breadcrumb-current { color: var(--text); font-weight: 500; }
+.breadcrumb-link { color: var(--text-secondary); }
 .breadcrumb-link:hover { color: var(--text); }
 
 .topbar-actions {
@@ -280,165 +299,180 @@ a { color: inherit; text-decoration: none; }
   gap: var(--sp-2);
 }
 
-/* ─── Page content ─────────────────────────────────────── */
+/* ─── Page content ───────────────────────────── */
 .page {
-  padding: var(--sp-8);
-  max-width: 1280px;
+  padding: var(--sp-6);
+  max-width: 1100px;
   width: 100%;
   margin: 0 auto;
 }
 
 .page-header {
   display: flex;
-  align-items: flex-end;
+  align-items: flex-start;
   justify-content: space-between;
-  margin-bottom: var(--sp-6);
+  margin-bottom: var(--sp-5);
+  gap: var(--sp-4);
 }
 
 .page-title {
-  font-size: 22px;
+  font-size: 20px;
   font-weight: 600;
-  letter-spacing: -0.5px;
-  margin: 0 0 4px;
+  letter-spacing: -0.4px;
+  margin: 0 0 2px;
 }
 
 .page-description {
-  font-size: 13px;
+  font-size: 12.5px;
   color: var(--text-secondary);
   margin: 0;
 }
 
-/* ─── Stats ────────────────────────────────────────────── */
-.stats {
-  display: grid;
-  grid-template-columns: repeat(4, 1fr);
-  gap: var(--sp-3);
-  margin-bottom: var(--sp-8);
-}
-
-.stat {
+/* ─── Stats strip (compact) ──────────────────── */
+.stats-strip {
+  display: flex;
+  gap: var(--sp-4);
+  padding: var(--sp-3) var(--sp-4);
   background: var(--bg-elevated);
   border: 1px solid var(--border);
   border-radius: var(--r-md);
-  padding: var(--sp-4) var(--sp-5);
-  transition: border-color 100ms;
-}
-.stat:hover { border-color: var(--border-strong); }
-
-.stat-label {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  font-size: 11.5px;
-  color: var(--text-secondary);
-  font-weight: 500;
-  margin-bottom: var(--sp-2);
+  margin-bottom: var(--sp-5);
 }
 
-.stat-dot {
-  width: 6px;
-  height: 6px;
-  border-radius: 50%;
-  flex-shrink: 0;
-}
-
-.stat-value {
-  font-size: 26px;
-  font-weight: 600;
-  letter-spacing: -1px;
-  font-variant-numeric: tabular-nums;
-}
-
-/* ─── Compose ──────────────────────────────────────────── */
-.compose {
-  background: var(--bg-elevated);
-  border: 1px solid var(--border);
-  border-radius: var(--r-md);
-  margin-bottom: var(--sp-8);
-  overflow: hidden;
-}
-
-.compose-header {
-  padding: var(--sp-3) var(--sp-5);
-  border-bottom: 1px solid var(--border);
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-}
-
-.compose-title {
-  font-size: 13px;
-  font-weight: 600;
-}
-
-.compose-platforms {
+.strip-stat {
   display: flex;
   align-items: center;
   gap: 6px;
   font-size: 12px;
+}
+
+.strip-label {
+  color: var(--text-tertiary);
+  font-weight: 500;
+}
+
+.strip-value {
+  font-family: var(--font-mono);
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+  color: var(--text);
+}
+
+/* ─── Compose ────────────────────────────────── */
+.compose {
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+  border-radius: var(--r-md);
+  margin-bottom: var(--sp-5);
+  overflow: hidden;
+  animation: slideDown 200ms ease-out;
+}
+
+@keyframes slideDown {
+  from { opacity: 0; transform: translateY(-8px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+.compose:focus-within {
+  border-color: var(--border-active);
+  box-shadow: 0 0 0 1px var(--accent-border), 0 0 20px -8px rgba(123, 97, 255, 0.1);
+}
+
+.compose-header {
+  padding: var(--sp-2) var(--sp-4);
+  border-bottom: 1px solid var(--border);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--sp-3);
+}
+
+.compose-title {
+  font-size: 12px;
+  font-weight: 600;
   color: var(--text-secondary);
 }
 
-.compose-body {
-  padding: var(--sp-3) var(--sp-5) 0;
+.platform-toggle {
+  display: flex;
+  gap: 2px;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: var(--r-sm);
+  padding: 2px;
 }
+
+.platform-toggle input[type="radio"] {
+  position: absolute; opacity: 0; pointer-events: none;
+}
+
+.platform-toggle label { cursor: pointer; display: block; }
+.platform-toggle label:has(input:disabled) { cursor: not-allowed; opacity: 0.4; }
+
+.pt-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 3px 8px;
+  border-radius: 4px;
+  font-size: 11px;
+  font-weight: 500;
+  color: var(--text-secondary);
+  transition: background 80ms, color 80ms;
+}
+
+.platform-toggle label:hover .pt-pill { color: var(--text); }
+.platform-toggle input:checked + .pt-pill {
+  background: var(--bg-elevated);
+  color: var(--text);
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.3);
+}
+
+.compose-body { padding: var(--sp-2) var(--sp-4) 0; }
 
 textarea {
   width: 100%;
-  min-height: 96px;
+  min-height: 72px;
   background: transparent;
   border: none;
-  padding: var(--sp-2) 0;
+  padding: var(--sp-1) 0;
   color: var(--text);
-  font-family: inherit;
-  font-size: 14px;
-  line-height: 1.55;
+  font-size: 13px;
+  line-height: 1.5;
   resize: vertical;
   outline: none;
 }
-
 textarea::placeholder { color: var(--text-tertiary); }
 
 .compose-footer {
-  padding: var(--sp-3) var(--sp-5);
+  padding: var(--sp-2) var(--sp-4);
   border-top: 1px solid var(--border);
   display: flex;
   justify-content: space-between;
   align-items: center;
-  gap: var(--sp-3);
-  background: rgba(0, 0, 0, 0.2);
+  background: rgba(0, 0, 0, 0.15);
 }
 
 .compose-toolbar {
   display: flex;
   align-items: center;
-  gap: var(--sp-2);
-  color: var(--text-tertiary);
+  gap: var(--sp-1);
 }
 
 .compose-toolbar button {
-  display: grid;
-  place-items: center;
-  width: 26px;
-  height: 26px;
+  display: grid; place-items: center;
+  width: 24px; height: 24px;
   border-radius: var(--r-sm);
   color: var(--text-tertiary);
-  transition: background 100ms, color 100ms;
+  transition: background 80ms, color 80ms;
 }
 .compose-toolbar button:hover { background: var(--bg-hover); color: var(--text); }
-.compose-toolbar button svg { width: 14px; height: 14px; stroke-width: 1.75; }
+.compose-toolbar button svg { width: 13px; height: 13px; stroke-width: 1.75; }
 
 .char-count {
-  font-size: 11.5px;
+  font-size: 10.5px;
   color: var(--text-tertiary);
-  font-variant-numeric: tabular-nums;
   font-family: var(--font-mono);
-}
-
-.char-count-divider {
-  width: 1px;
-  height: 14px;
-  background: var(--border);
 }
 
 .compose-submit {
@@ -447,30 +481,157 @@ textarea::placeholder { color: var(--text-tertiary); }
   align-items: center;
 }
 
-/* ─── Buttons ──────────────────────────────────────────── */
+/* ─── Compose mode tabs (Broadcast / Direct) ──────────────── */
+.compose-mode-tabs {
+  display: flex;
+  border-bottom: 1px solid var(--border);
+  background: rgba(0, 0, 0, 0.15);
+}
+.compose-tab {
+  padding: var(--sp-2) var(--sp-4);
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--text-tertiary);
+  background: transparent;
+  border: none;
+  border-bottom: 2px solid transparent;
+  cursor: pointer;
+  transition: color 80ms, border-color 80ms;
+}
+.compose-tab:hover { color: var(--text-secondary); }
+.compose-tab.active {
+  color: var(--text);
+  border-bottom-color: var(--accent-border, var(--text));
+}
+
+/* ─── Compose platform groups (broadcast checkboxes) ──────── */
+.compose-platforms {
+  padding: var(--sp-3) var(--sp-4);
+  border-bottom: 1px solid var(--border);
+}
+.compose-platforms-label {
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--text-tertiary);
+  margin-bottom: var(--sp-2);
+}
+.compose-platforms-groups {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--sp-3);
+}
+.compose-platform-group {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  min-width: 140px;
+}
+.cpg-name {
+  font-size: 10.5px;
+  font-weight: 600;
+  color: var(--text-secondary);
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+}
+.cp-check {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--sp-2);
+  font-size: 12px;
+  color: var(--text-secondary);
+  padding: 3px 6px;
+  border-radius: var(--r-sm);
+  cursor: pointer;
+  transition: background 80ms, color 80ms;
+}
+.cp-check:hover { background: var(--bg-hover); color: var(--text); }
+.cp-check input[type="checkbox"] {
+  width: 13px; height: 13px;
+  accent-color: var(--accent, #7b61ff);
+  cursor: pointer;
+}
+.cp-check.disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+.cp-check.disabled:hover { background: transparent; color: var(--text-secondary); }
+.cp-soon {
+  font-size: 10px;
+  color: var(--text-tertiary);
+  margin-left: auto;
+}
+.img-hint {
+  font-size: 10.5px;
+  color: var(--text-tertiary);
+  margin-left: auto;
+}
+
+/* ─── Image URL / WhatsApp rows ──────────────── */
+.img-row {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-3);
+  padding: var(--sp-1) 0;
+  margin-top: var(--sp-1);
+  border-top: 1px solid var(--border);
+}
+.img-label {
+  font-size: 10.5px;
+  font-weight: 500;
+  color: var(--text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  flex-shrink: 0;
+}
+.img-input {
+  flex: 1;
+  background: transparent;
+  border: none;
+  color: var(--text);
+  font-family: var(--font-mono);
+  font-size: 12px;
+  outline: none;
+  padding: 3px 0;
+}
+.img-input::placeholder { color: var(--text-tertiary); }
+
+.wa-select {
+  font-family: var(--font-sans);
+  font-size: 12px;
+  appearance: none;
+  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 24 24' fill='none' stroke='rgba(255,255,255,0.4)' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'><path d='M6 9l6 6 6-6'/></svg>");
+  background-repeat: no-repeat;
+  background-position: right 0 center;
+  padding-right: 16px;
+  cursor: pointer;
+}
+.wa-select option { background: var(--bg-elevated); color: var(--text); }
+
+/* ─── Buttons ────────────────────────────────── */
 .btn {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  gap: 6px;
-  padding: 6px var(--sp-3);
+  gap: 5px;
+  padding: 5px var(--sp-3);
   border-radius: var(--r-sm);
-  font-size: 13px;
+  font-size: 12.5px;
   font-weight: 500;
-  letter-spacing: -0.1px;
-  transition: background 100ms, border-color 100ms, color 100ms;
+  transition: background 80ms, border-color 80ms, color 80ms;
   white-space: nowrap;
   border: 1px solid transparent;
 }
-
 .btn svg { width: 13px; height: 13px; stroke-width: 2; }
+.btn:active:not(:disabled) { transform: scale(0.97); }
 
 .btn-primary {
   background: var(--text);
   color: var(--bg);
   font-weight: 600;
 }
-.btn-primary:hover { background: rgba(255, 255, 255, 0.9); }
+.btn-primary:hover { background: rgba(255, 255, 255, 0.88); }
 
 .btn-secondary {
   background: var(--bg-elevated);
@@ -479,9 +640,7 @@ textarea::placeholder { color: var(--text-tertiary); }
 }
 .btn-secondary:hover { background: var(--bg-hover); border-color: var(--border-active); }
 
-.btn-ghost {
-  color: var(--text-secondary);
-}
+.btn-ghost { color: var(--text-secondary); }
 .btn-ghost:hover { background: var(--bg-hover); color: var(--text); }
 
 .btn-success {
@@ -491,164 +650,24 @@ textarea::placeholder { color: var(--text-tertiary); }
 }
 .btn-success:hover { background: #16a34a; }
 
-.btn-danger {
-  color: var(--status-error);
-}
+.btn-danger { color: var(--status-error); }
 .btn-danger:hover { background: rgba(239, 68, 68, 0.1); }
 
-.btn-sm { padding: 4px var(--sp-2); font-size: 12px; }
-.btn-icon { width: 28px; height: 28px; padding: 0; }
+.btn-sm { padding: 3px var(--sp-2); font-size: 11.5px; }
+.btn-icon { width: 26px; height: 26px; padding: 0; }
 
-/* ─── Platform toggle (segmented control) ─────────────── */
-.platform-toggle {
-  display: flex;
-  gap: 4px;
-  background: var(--bg);
-  border: 1px solid var(--border);
-  border-radius: var(--r);
-  padding: 3px;
-}
-
-.platform-toggle input[type="radio"] {
-  position: absolute;
-  opacity: 0;
-  pointer-events: none;
-}
-
-.platform-toggle label {
-  cursor: pointer;
-  display: block;
-}
-
-.platform-toggle label:has(input:disabled) {
-  cursor: not-allowed;
-  opacity: 0.45;
-}
-
-.pt-pill {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  padding: 4px 10px;
-  border-radius: 5px;
-  font-size: 12px;
-  font-weight: 500;
-  color: var(--text-secondary);
-  transition: background 100ms, color 100ms;
-}
-
-.platform-toggle label:hover .pt-pill {
-  color: var(--text);
-}
-
-.platform-toggle input:checked + .pt-pill {
-  background: var(--bg-elevated);
-  color: var(--text);
-  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.3);
-}
-
-.pt-handle {
-  font-family: var(--font-mono);
-  font-size: 10.5px;
-  color: var(--text-tertiary);
-  margin-left: 2px;
-}
-
-/* ─── Image URL input row ─────────────────────────────── */
-.img-row {
-  display: flex;
-  align-items: center;
-  gap: var(--sp-3);
-  padding: var(--sp-2) 0;
-  margin-top: var(--sp-2);
-  border-top: 1px solid var(--border);
-}
-
-.img-label {
-  font-size: 11.5px;
-  font-weight: 500;
-  color: var(--text-secondary);
-  text-transform: uppercase;
-  letter-spacing: 0.5px;
-  flex-shrink: 0;
-}
-
-.img-input {
-  flex: 1;
-  background: transparent;
-  border: none;
-  color: var(--text);
-  font-family: var(--font-mono);
-  font-size: 12.5px;
-  outline: none;
-  padding: 4px 0;
-}
-
-.img-input::placeholder { color: var(--text-tertiary); }
-
-.wa-select {
-  font-family: var(--font-sans);
-  font-size: 12.5px;
-  appearance: none;
-  -webkit-appearance: none;
-  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 24 24' fill='none' stroke='rgba(255,255,255,0.4)' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'><path d='M6 9l6 6 6-6'/></svg>");
-  background-repeat: no-repeat;
-  background-position: right 0 center;
-  padding-right: 18px;
-  cursor: pointer;
-}
-
-.wa-select option { background: var(--bg-elevated); color: var(--text); }
-
-/* ─── Tabs ─────────────────────────────────────────────── */
-.tabs {
-  display: flex;
-  align-items: center;
-  border-bottom: 1px solid var(--border);
-  margin-bottom: var(--sp-5);
-  gap: 0;
-}
-
-.tab {
-  padding: var(--sp-2) var(--sp-3);
-  font-size: 13px;
-  font-weight: 500;
-  color: var(--text-secondary);
-  border-bottom: 1.5px solid transparent;
-  margin-bottom: -1px;
-  cursor: pointer;
-  transition: color 100ms, border-color 100ms;
-  display: flex;
-  align-items: center;
-  gap: 6px;
-}
-
-.tab:hover { color: var(--text); }
-.tab.active { color: var(--text); border-bottom-color: var(--text); }
-
-.tab .badge {
-  font-size: 10.5px;
-  font-family: var(--font-mono);
-  background: var(--bg-elevated);
-  padding: 1px 5px;
-  border-radius: 4px;
-  color: var(--text-secondary);
-}
-
-/* ─── Post list ────────────────────────────────────────── */
-.section {
-  margin-bottom: var(--sp-8);
-}
+/* ─── Sections ───────────────────────────────── */
+.section { margin-bottom: var(--sp-6); }
 
 .section-header {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  margin-bottom: var(--sp-3);
+  margin-bottom: var(--sp-2);
 }
 
 .section-title {
-  font-size: 13px;
+  font-size: 12.5px;
   font-weight: 600;
   letter-spacing: -0.1px;
   display: flex;
@@ -657,12 +676,12 @@ textarea::placeholder { color: var(--text-tertiary); }
 }
 
 .section-count {
-  font-size: 11.5px;
+  font-size: 11px;
   font-family: var(--font-mono);
   color: var(--text-tertiary);
-  font-variant-numeric: tabular-nums;
 }
 
+/* ─── Post list ──────────────────────────────── */
 .post-list {
   background: var(--bg-elevated);
   border: 1px solid var(--border);
@@ -674,31 +693,35 @@ textarea::placeholder { color: var(--text-tertiary); }
   display: grid;
   grid-template-columns: auto 1fr auto auto;
   align-items: center;
-  gap: var(--sp-4);
-  padding: var(--sp-3) var(--sp-5);
+  gap: var(--sp-3);
+  padding: var(--sp-2) var(--sp-4);
   border-bottom: 1px solid var(--border);
-  transition: background 100ms;
+  transition: background 80ms;
+  animation: rowIn 150ms ease-out;
 }
 
 .post-row:last-child { border-bottom: none; }
 .post-row:hover { background: var(--bg-hover); }
 
+@keyframes rowIn {
+  from { opacity: 0; transform: translateY(-2px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
 .post-status {
   display: flex;
   align-items: center;
   gap: var(--sp-2);
-  min-width: 0;
 }
 
 .post-status-dot {
-  width: 6px;
-  height: 6px;
+  width: 6px; height: 6px;
   border-radius: 50%;
   flex-shrink: 0;
 }
 
 .post-status-label {
-  font-size: 11.5px;
+  font-size: 10.5px;
   text-transform: uppercase;
   letter-spacing: 0.4px;
   font-weight: 600;
@@ -706,7 +729,7 @@ textarea::placeholder { color: var(--text-tertiary); }
 }
 
 .post-message {
-  font-size: 13.5px;
+  font-size: 13px;
   color: var(--text);
   overflow: hidden;
   white-space: nowrap;
@@ -718,45 +741,86 @@ textarea::placeholder { color: var(--text-tertiary); }
   display: flex;
   align-items: center;
   gap: var(--sp-2);
-  font-size: 11.5px;
+  font-size: 11px;
   color: var(--text-tertiary);
-  font-variant-numeric: tabular-nums;
   font-family: var(--font-mono);
   white-space: nowrap;
 }
 
 .post-actions {
   display: flex;
-  gap: 4px;
-  opacity: 0.65;
-  transition: opacity 100ms;
+  gap: 3px;
+  opacity: 0;
+  transition: opacity 80ms;
 }
 .post-row:hover .post-actions { opacity: 1; }
 
-.post-row.expanded .post-message {
-  white-space: normal;
-}
-
-/* Pending row gets a more prominent treatment */
+/* Pending rows */
 .post-row.pending {
-  background: rgba(234, 179, 8, 0.04);
+  background: rgba(234, 179, 8, 0.03);
+  position: relative;
 }
-.post-row.pending:hover {
-  background: rgba(234, 179, 8, 0.08);
+.post-row.pending:hover { background: rgba(234, 179, 8, 0.07); }
+.post-row.pending .post-message { white-space: normal; }
+.post-row.pending .post-actions { opacity: 1; }
+
+.post-row.pending::before {
+  content: '';
+  position: absolute;
+  left: 0; top: 0; bottom: 0;
+  width: 2px;
+  background: var(--status-pending);
+  border-radius: 0 2px 2px 0;
 }
 
-.post-row.pending .post-message {
-  white-space: normal;
+/* ─── Grouped (broadcast) post card ──────────────── */
+.post-row.post-group {
+  grid-template-columns: auto 1fr auto auto;
+  grid-template-rows: auto auto;
+  row-gap: var(--sp-1);
+}
+.post-row.post-group .post-message { grid-column: 2 / 3; grid-row: 1; }
+.post-row.post-group .post-status   { grid-column: 1; grid-row: 1 / 3; align-self: start; padding-top: 4px; }
+.post-row.post-group .post-meta     { grid-column: 3; grid-row: 1; }
+.post-row.post-group .post-actions  { grid-column: 4; grid-row: 1 / 3; }
+.post-row.post-group .post-group-platforms {
+  grid-column: 2 / 4;
+  grid-row: 2;
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--sp-2);
+}
+.post-group-platform {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 10.5px;
+  color: var(--text-tertiary);
+  padding: 2px 6px;
+  border: 1px solid var(--border);
+  border-radius: 99px;
+  background: var(--bg);
+}
+.post-group-count {
+  font-size: 10px;
+  font-weight: 500;
+  color: var(--text-tertiary);
+  text-transform: lowercase;
+  letter-spacing: 0;
+  padding: 1px 6px;
+  border: 1px solid var(--border);
+  border-radius: 99px;
+  margin-left: var(--sp-1);
 }
 
 .post-error {
   grid-column: 1 / -1;
   margin-top: var(--sp-1);
-  padding: 6px var(--sp-3);
-  background: rgba(239, 68, 68, 0.06);
-  border: 1px solid rgba(239, 68, 68, 0.15);
+  padding: 4px var(--sp-3);
+  background: rgba(239, 68, 68, 0.05);
+  border: 1px solid rgba(239, 68, 68, 0.12);
   border-radius: var(--r-sm);
-  font-size: 11.5px;
+  font-size: 11px;
   color: var(--status-error);
   font-family: var(--font-mono);
   word-break: break-word;
@@ -766,7 +830,6 @@ textarea::placeholder { color: var(--text-tertiary); }
   font-size: 11px;
   color: var(--accent);
   font-family: var(--font-mono);
-  text-decoration: none;
   display: inline-flex;
   align-items: center;
   gap: 3px;
@@ -775,70 +838,219 @@ textarea::placeholder { color: var(--text-tertiary); }
 .post-link svg { width: 10px; height: 10px; stroke-width: 2; }
 
 /* Status dots */
-.s-pending { background: var(--status-pending); box-shadow: 0 0 0 3px rgba(234, 179, 8, 0.15); }
-.s-success { background: var(--status-success); box-shadow: 0 0 0 3px rgba(34, 197, 94, 0.15); }
-.s-error   { background: var(--status-error);   box-shadow: 0 0 0 3px rgba(239, 68, 68, 0.15); }
+.stat-dot, .cal-dot {
+  width: 6px; height: 6px;
+  border-radius: 50%;
+  flex-shrink: 0;
+  display: inline-block;
+}
+.s-pending { background: var(--status-pending); box-shadow: 0 0 0 2px rgba(234, 179, 8, 0.15); }
+.s-success { background: var(--status-success); box-shadow: 0 0 0 2px rgba(34, 197, 94, 0.15); }
+.s-error   { background: var(--status-error);   box-shadow: 0 0 0 2px rgba(239, 68, 68, 0.15); }
 .s-neutral { background: var(--status-neutral); }
 
-/* ─── Empty state ──────────────────────────────────────── */
+/* ─── Empty state ────────────────────────────── */
 .empty {
-  padding: var(--sp-12) var(--sp-6);
+  padding: var(--sp-10) var(--sp-6);
   text-align: center;
   color: var(--text-tertiary);
 }
 
 .empty-icon {
-  width: 36px;
-  height: 36px;
+  width: 32px; height: 32px;
   margin: 0 auto var(--sp-3);
-  border-radius: 8px;
+  border-radius: 7px;
   background: var(--bg-hover);
-  display: grid;
-  place-items: center;
+  display: grid; place-items: center;
   border: 1px solid var(--border);
 }
-
-.empty-icon svg { width: 18px; height: 18px; stroke-width: 1.5; color: var(--text-tertiary); }
+.empty-icon svg { width: 16px; height: 16px; stroke-width: 1.5; color: var(--text-tertiary); }
 
 .empty-title {
   font-size: 13px;
   font-weight: 500;
   color: var(--text);
-  margin-bottom: 4px;
+  margin-bottom: 3px;
 }
-
 .empty-body {
-  font-size: 12.5px;
+  font-size: 12px;
   color: var(--text-tertiary);
 }
 
-/* ─── Kbd / Code ──────────────────────────────────────── */
+/* ─── Bulk action bar ────────────────────────── */
+.bulk-bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: var(--sp-2) var(--sp-3);
+  background: var(--accent-bg);
+  border: 1px solid var(--accent-border);
+  border-radius: var(--r);
+  margin-bottom: var(--sp-3);
+  font-size: 12px;
+}
+.bulk-bar-text {
+  color: var(--text);
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+.bulk-bar-text strong {
+  font-family: var(--font-mono);
+  background: var(--accent-bg-strong);
+  padding: 0 5px;
+  border-radius: 3px;
+  font-weight: 500;
+}
+
+/* ─── Calendar ───────────────────────────────── */
+.cal-nav {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-2);
+}
+
+.cal-range {
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--text);
+  margin-left: var(--sp-2);
+}
+
+.cal-grid {
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+  border-radius: var(--r-md);
+  overflow: hidden;
+}
+
+.cal-header {
+  display: grid;
+  grid-template-columns: 48px repeat(7, 1fr);
+  border-bottom: 1px solid var(--border);
+}
+
+.cal-time-gutter {
+  padding: var(--sp-2) var(--sp-2);
+  font-size: 10px;
+  color: var(--text-tertiary);
+  font-family: var(--font-mono);
+  text-align: right;
+  border-right: 1px solid var(--border);
+  display: flex;
+  align-items: flex-start;
+  justify-content: flex-end;
+}
+
+.cal-day-header {
+  padding: var(--sp-2) var(--sp-3);
+  text-align: center;
+  border-right: 1px solid var(--border);
+}
+.cal-day-header:last-child { border-right: none; }
+
+.cal-day-name {
+  display: block;
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: var(--text-tertiary);
+}
+
+.cal-day-num {
+  display: block;
+  font-size: 16px;
+  font-weight: 600;
+  color: var(--text);
+  margin-top: 1px;
+}
+
+.cal-day-header.cal-today .cal-day-num {
+  color: var(--accent);
+}
+
+.cal-body {
+  max-height: calc(100vh - 240px);
+  overflow-y: auto;
+}
+
+.cal-row {
+  display: grid;
+  grid-template-columns: 48px repeat(7, 1fr);
+  min-height: 48px;
+  border-bottom: 1px solid var(--border);
+}
+.cal-row:last-child { border-bottom: none; }
+
+.cal-cell {
+  border-right: 1px solid var(--border);
+  padding: 2px 3px;
+  min-height: 48px;
+  position: relative;
+  transition: background 80ms;
+}
+.cal-cell:last-child { border-right: none; }
+.cal-cell:hover { background: var(--bg-hover); }
+.cal-cell.cal-today-col { background: rgba(123, 97, 255, 0.03); }
+.cal-cell.cal-drop-target { background: var(--accent-bg); outline: 1px dashed var(--accent-border); outline-offset: -1px; }
+
+.cal-event {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 2px 6px;
+  border-radius: 4px;
+  font-size: 10.5px;
+  margin-bottom: 2px;
+  cursor: grab;
+  transition: opacity 80ms, transform 80ms;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+.cal-event:active { cursor: grabbing; }
+.cal-event.cal-dragging { opacity: 0.4; transform: scale(0.95); }
+
+.cal-ev-published { background: rgba(34, 197, 94, 0.1); color: var(--status-success); }
+.cal-ev-scheduled { background: rgba(234, 179, 8, 0.1); color: var(--status-pending); }
+.cal-ev-pending   { background: rgba(123, 97, 255, 0.1); color: var(--accent); }
+.cal-ev-failed    { background: rgba(239, 68, 68, 0.08); color: var(--status-error); }
+
+.cal-ev-text {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-weight: 500;
+}
+
+/* ─── Kbd / Code ─────────────────────────────── */
 kbd, .kbd {
   font-family: var(--font-mono);
-  font-size: 10.5px;
-  padding: 1px 5px;
+  font-size: 10px;
+  padding: 1px 4px;
   background: var(--bg-elevated);
   border: 1px solid var(--border-strong);
   border-bottom-width: 2px;
-  border-radius: 4px;
+  border-radius: 3px;
   color: var(--text-secondary);
 }
 
 code.kbd {
   font-family: var(--font-mono);
-  font-size: 12px;
-  padding: 2px 6px;
+  font-size: 11.5px;
+  padding: 1px 5px;
   background: var(--bg-hover);
   border: 1px solid var(--border);
-  border-radius: 4px;
+  border-radius: 3px;
   color: var(--accent);
 }
 
-/* ─── Toasts ──────────────────────────────────────────── */
+/* ─── Toasts ─────────────────────────────────── */
 #toast-host {
   position: fixed;
-  bottom: var(--sp-5);
-  right: var(--sp-5);
+  bottom: var(--sp-4);
+  right: var(--sp-4);
   display: flex;
   flex-direction: column;
   gap: var(--sp-2);
@@ -850,41 +1062,40 @@ code.kbd {
   display: flex;
   align-items: center;
   gap: var(--sp-3);
-  padding: 10px 14px;
+  padding: 8px 12px;
   background: var(--bg-elevated);
   border: 1px solid var(--border-strong);
   border-radius: var(--r);
-  font-size: 13px;
+  font-size: 12.5px;
   font-weight: 500;
   color: var(--text);
-  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.5), 0 0 0 1px rgba(255,255,255,0.04);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4);
   pointer-events: auto;
-  min-width: 240px;
-  max-width: 360px;
-  animation: toastIn 220ms cubic-bezier(0.2, 0.9, 0.32, 1.28);
-  backdrop-filter: blur(12px);
+  min-width: 200px;
+  max-width: 340px;
+  animation: toastIn 200ms cubic-bezier(0.2, 0.9, 0.32, 1.28);
 }
 
-.toast-leave { animation: toastOut 360ms ease-in forwards; }
+.toast-leave { animation: toastOut 300ms ease-in forwards; }
 
 @keyframes toastIn {
-  from { transform: translateY(8px) scale(0.96); opacity: 0; }
+  from { transform: translateY(6px) scale(0.96); opacity: 0; }
   to   { transform: translateY(0) scale(1); opacity: 1; }
 }
 @keyframes toastOut {
   from { transform: translateY(0); opacity: 1; }
-  to   { transform: translateY(-8px); opacity: 0; }
+  to   { transform: translateY(-6px); opacity: 0; }
 }
 
 .toast-dot {
-  width: 8px;
-  height: 8px;
+  width: 7px; height: 7px;
   border-radius: 50%;
   flex-shrink: 0;
 }
-.toast-dot-success { background: var(--status-success); box-shadow: 0 0 0 4px rgba(34, 197, 94, 0.18); }
-.toast-dot-error   { background: var(--status-error);   box-shadow: 0 0 0 4px rgba(239, 68, 68, 0.18); }
-.toast-dot-info    { background: var(--accent);         box-shadow: 0 0 0 4px var(--accent-bg); }
+.toast-dot-success { background: var(--status-success); }
+.toast-dot-error   { background: var(--status-error); }
+.toast-dot-info    { background: var(--accent); }
+.toast-dot-warning { background: var(--status-pending); }
 
 .toast-text { flex: 1; line-height: 1.4; }
 
@@ -892,25 +1103,22 @@ code.kbd {
   background: transparent;
   border: none;
   color: var(--text-tertiary);
-  font-size: 18px;
-  line-height: 1;
+  font-size: 16px;
   padding: 0;
   cursor: pointer;
-  width: 18px;
-  height: 18px;
-  display: grid;
-  place-items: center;
-  border-radius: 4px;
+  width: 16px; height: 16px;
+  display: grid; place-items: center;
+  border-radius: 3px;
 }
 .toast-close:hover { color: var(--text); background: var(--bg-hover); }
 
-.toast-success { border-color: rgba(34, 197, 94, 0.25); }
-.toast-error   { border-color: rgba(239, 68, 68, 0.25); }
+.toast-success { border-color: rgba(34, 197, 94, 0.2); }
+.toast-error   { border-color: rgba(239, 68, 68, 0.2); }
 
-/* ─── Settings page ───────────────────────────────────── */
+/* ─── Settings ───────────────────────────────── */
 .acc-name { min-width: 0; }
 .acc-name-primary {
-  font-size: 13.5px;
+  font-size: 13px;
   color: var(--text);
   font-weight: 500;
   overflow: hidden;
@@ -918,21 +1126,21 @@ code.kbd {
   white-space: nowrap;
 }
 .acc-name-secondary {
-  font-size: 11.5px;
+  font-size: 11px;
   color: var(--text-tertiary);
-  margin-top: 2px;
+  margin-top: 1px;
 }
 
 .conn-status {
-  font-size: 11.5px;
+  font-size: 11px;
   font-weight: 500;
-  padding: 2px 8px;
+  padding: 1px 7px;
   border-radius: 999px;
   white-space: nowrap;
 }
 .conn-status.ok {
   color: var(--status-success);
-  background: rgba(34, 197, 94, 0.1);
+  background: rgba(34, 197, 94, 0.08);
 }
 .conn-status.off {
   color: var(--text-tertiary);
@@ -941,43 +1149,41 @@ code.kbd {
 
 .env-value code {
   font-family: var(--font-mono);
-  font-size: 12px;
+  font-size: 11.5px;
   color: var(--text-secondary);
   word-break: break-all;
 }
 
 .env-help {
-  font-size: 12.5px;
+  font-size: 12px;
   color: var(--text-tertiary);
   margin-top: var(--sp-2);
 }
 .env-help a { color: var(--accent); }
 .env-help a:hover { text-decoration: underline; }
 
-/* ─── Tooltips ─────────────────────────────────────────── */
-[data-tip] {
-  position: relative;
-}
+/* ─── Tooltips ───────────────────────────────── */
+[data-tip] { position: relative; }
 
 [data-tip]::after {
   content: attr(data-tip);
   position: absolute;
-  bottom: calc(100% + 6px);
+  bottom: calc(100% + 5px);
   left: 50%;
   transform: translateX(-50%) translateY(2px);
-  padding: 4px 8px;
-  border-radius: 5px;
+  padding: 3px 7px;
+  border-radius: 4px;
   background: #1f1f1f;
   border: 1px solid var(--border-strong);
   color: var(--text);
-  font-size: 11.5px;
+  font-size: 11px;
   font-weight: 500;
   white-space: nowrap;
   pointer-events: none;
   opacity: 0;
-  transition: opacity 100ms 200ms, transform 100ms 200ms;
+  transition: opacity 80ms 150ms, transform 80ms 150ms;
   z-index: 100;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.3);
 }
 
 [data-tip]:hover::after {
@@ -987,27 +1193,14 @@ code.kbd {
 
 [data-tip-place="bottom"]::after {
   bottom: auto;
-  top: calc(100% + 6px);
+  top: calc(100% + 5px);
   transform: translateX(-50%) translateY(-2px);
 }
 [data-tip-place="bottom"]:hover::after {
   transform: translateX(-50%) translateY(0);
 }
 
-/* ─── Skeleton loader (HTMX active) ─────────────────────── */
-.skeleton {
-  background: linear-gradient(90deg, var(--bg-elevated) 0%, var(--bg-hover) 50%, var(--bg-elevated) 100%);
-  background-size: 200% 100%;
-  animation: shimmer 1.4s infinite;
-  border-radius: var(--r-sm);
-}
-
-@keyframes shimmer {
-  0% { background-position: 200% 0; }
-  100% { background-position: -200% 0; }
-}
-
-/* ─── Focus rings (keyboard a11y) ─────────────────────── */
+/* ─── Focus / A11y ───────────────────────────── */
 :focus-visible {
   outline: 2px solid var(--accent);
   outline-offset: 2px;
@@ -1015,239 +1208,181 @@ code.kbd {
 }
 
 textarea:focus, button:focus, .nav-item:focus { outline: none; }
+textarea:focus-visible { outline: none; box-shadow: inset 0 0 0 1px var(--accent); }
 
-textarea:focus-visible {
-  outline: none;
-  box-shadow: inset 0 0 0 1px var(--accent);
-}
-
-.compose:focus-within {
-  border-color: var(--border-active);
-}
-
-/* ─── Bulk action bar ─────────────────────────────────── */
-.bulk-bar {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: var(--sp-2) var(--sp-3);
-  background: var(--accent-bg);
-  border: 1px solid var(--accent-border);
-  border-radius: var(--r);
-  margin-bottom: var(--sp-3);
-  font-size: 12.5px;
-}
-
-.bulk-bar-text {
-  color: var(--text);
-  display: flex;
-  align-items: center;
-  gap: 6px;
-}
-
-.bulk-bar-text strong {
-  font-family: var(--font-mono);
-  background: var(--accent-bg-strong);
-  padding: 1px 6px;
-  border-radius: 4px;
-  font-weight: 500;
-}
-
-/* ─── Row entrance animation ──────────────────────────── */
-.post-row {
-  animation: rowIn 200ms ease-out;
-}
-
-@keyframes rowIn {
-  from { opacity: 0; transform: translateY(-2px); }
-  to { opacity: 1; transform: translateY(0); }
-}
-
-/* ─── HTMX states ──────────────────────────────────────── */
+/* ─── HTMX states ────────────────────────────── */
 .htmx-request .btn-primary,
 .htmx-request .btn-success { opacity: 0.7; pointer-events: none; }
 .htmx-indicator { display: none; }
 .htmx-request .htmx-indicator { display: inline-block; animation: spin 800ms linear infinite; }
-
-.htmx-swapping {
-  opacity: 0;
-  transition: opacity 120ms ease-out;
-}
-
+.htmx-swapping { opacity: 0; transition: opacity 100ms ease-out; }
 @keyframes spin { to { transform: rotate(360deg); } }
 
-/* ─── Account switcher ──────────────────────────────────── */
-.account-switcher {
-  display: flex;
-  align-items: center;
-  gap: var(--sp-2);
-  padding: 5px var(--sp-2);
-  background: var(--bg-elevated);
-  border: 1px solid var(--border);
-  border-radius: var(--r-sm);
-  font-size: 12.5px;
-  color: var(--text);
-  cursor: pointer;
-  transition: background 100ms, border-color 100ms;
-}
-.account-switcher:hover { background: var(--bg-hover); border-color: var(--border-strong); }
-
-.account-avatar {
-  width: 18px;
-  height: 18px;
-  border-radius: 4px;
-  background: var(--gradient);
-  display: grid;
-  place-items: center;
-  color: #fff;
-  font-size: 9.5px;
-  font-weight: 700;
-}
-
-.account-switcher svg { width: 12px; height: 12px; color: var(--text-tertiary); stroke-width: 1.75; }
-
-/* ─── Topbar gradient line ────────────────────────────── */
-.topbar::after {
-  content: '';
-  position: absolute;
-  bottom: 0;
-  left: 0;
-  right: 0;
-  height: 1px;
-  background: linear-gradient(90deg, transparent 0%, var(--border-strong) 20%, var(--accent-border) 50%, var(--border-strong) 80%, transparent 100%);
-  opacity: 0.6;
-}
-
-/* ─── Compose glow on focus ──────────────────────────── */
-.compose:focus-within {
-  box-shadow: 0 0 0 1px var(--accent-border), 0 0 24px -8px rgba(123, 97, 255, 0.12);
-}
-
-/* ─── Stats card number animation ────────────────────── */
-.stat:hover .stat-value {
-  color: var(--accent);
-  transition: color 200ms;
-}
-
-/* ─── Smooth button press ────────────────────────────── */
-.btn:active:not(:disabled) {
-  transform: scale(0.97);
-  transition: transform 60ms;
-}
-
-.btn-primary:active:not(:disabled) {
-  background: rgba(255, 255, 255, 0.82);
-}
-
-.btn-success:active:not(:disabled) {
-  background: #15803d;
-}
-
-/* ─── Sidebar active indicator ───────────────────────── */
-.nav-item.active::before {
-  content: '';
-  position: absolute;
-  left: -12px;
-  top: 50%;
-  transform: translateY(-50%);
-  width: 3px;
-  height: 16px;
-  border-radius: 0 3px 3px 0;
-  background: var(--accent);
-}
-
-.nav-item {
-  position: relative;
-}
-
-/* ─── Better scroll bar ──────────────────────────────── */
-::-webkit-scrollbar { width: 6px; height: 6px; }
+/* ─── Scrollbar ──────────────────────────────── */
+::-webkit-scrollbar { width: 5px; height: 5px; }
 ::-webkit-scrollbar-track { background: transparent; }
-::-webkit-scrollbar-thumb {
-  background: var(--border-strong);
-  border-radius: 3px;
-}
+::-webkit-scrollbar-thumb { background: var(--border-strong); border-radius: 3px; }
 ::-webkit-scrollbar-thumb:hover { background: var(--text-quaternary); }
 
-/* ─── Selection colour ───────────────────────────────── */
 ::selection {
   background: var(--accent-bg-strong);
   color: var(--text);
 }
 
-/* ─── Compose toolbar active state ───────────────────── */
-.compose-toolbar button:active {
-  transform: scale(0.92);
-  transition: transform 60ms;
-}
-
-/* ─── Post row hover highlight ───────────────────────── */
-.post-row.pending::before {
-  content: '';
-  position: absolute;
-  left: 0;
-  top: 0;
-  bottom: 0;
-  width: 2px;
-  background: var(--status-pending);
-  border-radius: 0 2px 2px 0;
-  opacity: 0;
-  transition: opacity 150ms;
-}
-
-.post-row.pending {
-  position: relative;
-}
-
-.post-row.pending:hover::before {
-  opacity: 1;
-}
-
-/* ─── Settings page polish ───────────────────────────── */
-.post-row .platform-icon {
-  transition: transform 150ms;
-}
-.post-row:hover .platform-icon {
-  transform: scale(1.1);
-}
-
-/* ─── Mobile hamburger area ──────────────────────────── */
+/* ─── Mobile hamburger ───────────────────────── */
 .mobile-nav-toggle {
   display: none;
   padding: var(--sp-2);
   margin-right: var(--sp-2);
 }
 .mobile-nav-toggle svg {
-  width: 18px;
-  height: 18px;
+  width: 16px; height: 16px;
   stroke-width: 1.75;
   color: var(--text-secondary);
 }
 
-/* ─── Responsive ──────────────────────────────────────── */
+/* ─── Responsive ─────────────────────────────── */
 @media (max-width: 1024px) {
   .app { grid-template-columns: 1fr; }
-  .sidebar { display: none; }
-  .stats { grid-template-columns: repeat(2, 1fr); }
+  .sidebar {
+    display: none;
+    position: fixed;
+    top: 0; left: 0; bottom: 0;
+    width: var(--sidebar-w);
+    z-index: 100;
+  }
+  .sidebar.sidebar-open { display: flex; }
   .mobile-nav-toggle { display: grid; place-items: center; }
   .compose-header { flex-direction: column; gap: var(--sp-2); align-items: flex-start; }
   .platform-toggle { width: 100%; }
+  .stats-strip { flex-wrap: wrap; }
+  .cal-nav { flex-wrap: wrap; }
 }
 
 @media (max-width: 640px) {
   .page { padding: var(--sp-4); }
-  .page-title { font-size: 20px; }
-  .post-row { grid-template-columns: auto 1fr; gap: var(--sp-2); padding: var(--sp-3) var(--sp-4); }
+  .page-title { font-size: 18px; }
+  .page-header { flex-direction: column; gap: var(--sp-2); }
+  .post-row { grid-template-columns: auto 1fr; gap: var(--sp-2); padding: var(--sp-2) var(--sp-3); }
   .post-meta, .post-actions { grid-column: 2; opacity: 1; }
   .post-meta { flex-wrap: wrap; }
-  .stats { grid-template-columns: 1fr 1fr; gap: var(--sp-2); }
-  .stat { padding: var(--sp-3) var(--sp-4); }
-  .stat-value { font-size: 22px; }
   .compose-footer { flex-direction: column; gap: var(--sp-2); }
   .compose-submit { width: 100%; justify-content: space-between; }
   .bulk-bar { flex-direction: column; gap: var(--sp-2); text-align: center; }
-  .topbar { padding: 0 var(--sp-4); }
-  .account-switcher { display: none; }
+  .topbar { padding: 0 var(--sp-3); }
+  .stats-strip { gap: var(--sp-2); padding: var(--sp-2) var(--sp-3); }
+}
+
+/* ─── Login page ────────────────────────────── */
+.login-page {
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  background: var(--bg);
+  padding: var(--sp-6);
+}
+
+.login-wrapper {
+  width: 100%;
+  max-width: 360px;
+}
+
+.login-card {
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+  border-radius: var(--r-lg);
+  padding: var(--sp-8) var(--sp-6);
+}
+
+.login-brand {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-3);
+  margin-bottom: var(--sp-6);
+}
+
+.login-subtitle {
+  font-size: 12.5px;
+  color: var(--text-secondary);
+  margin: 0 0 var(--sp-5);
+  line-height: 1.5;
+}
+
+.login-error {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-2);
+  background: rgba(239, 68, 68, 0.08);
+  border: 1px solid rgba(239, 68, 68, 0.2);
+  border-radius: var(--r-sm);
+  padding: var(--sp-2) var(--sp-3);
+  margin-bottom: var(--sp-4);
+  color: #fca5a5;
+  font-size: 12.5px;
+  font-weight: 500;
+}
+
+.login-form {
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-3);
+}
+
+.login-label {
+  font-size: 11.5px;
+  font-weight: 500;
+  color: var(--text-secondary);
+}
+
+.login-input {
+  width: 100%;
+  padding: var(--sp-2) var(--sp-3);
+  background: var(--bg);
+  border: 1px solid var(--border-strong);
+  border-radius: var(--r-sm);
+  color: var(--text);
+  font-size: 13px;
+  outline: none;
+  transition: border-color 80ms, box-shadow 80ms;
+}
+
+.login-input:focus {
+  border-color: var(--accent-border);
+  box-shadow: 0 0 0 1px var(--accent-border), 0 0 20px -8px rgba(123, 97, 255, 0.15);
+}
+
+.login-input::placeholder { color: var(--text-tertiary); }
+
+.login-submit {
+  width: 100%;
+  padding: var(--sp-2) var(--sp-4);
+  margin-top: var(--sp-1);
+}
+
+/* ─── Logout button in sidebar ──────────────── */
+.logout-btn {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-2);
+  padding: 5px var(--sp-2);
+  border-radius: var(--r-sm);
+  font-size: 12.5px;
+  font-weight: 500;
+  color: var(--text-secondary);
+  transition: background 80ms, color 80ms;
+  width: 100%;
+  cursor: pointer;
+  border: none;
+  background: transparent;
+}
+
+.logout-btn:hover { background: var(--bg-hover); color: var(--text); }
+
+.logout-btn svg {
+  width: 14px; height: 14px;
+  flex-shrink: 0;
+  stroke-width: 1.75;
+  opacity: 0.75;
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/dashboard/templates/_base.html
+++ b/dashboard/templates/_base.html
@@ -1,0 +1,121 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>{% block title %}Social Auto Engine{% endblock %}</title>
+  <link rel="icon" type="image/svg+xml" href="/static/favicon.svg">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="/static/styles.css">
+  <script src="https://unpkg.com/htmx.org@2.0.4" integrity="sha384-HGfztofotfshcF7+8n44JQL2oJmowVChPTg48S+jvZoztPfvwD79OC/LTtG6dMp+" crossorigin="anonymous"></script>
+  {% block head %}{% endblock %}
+</head>
+<body>
+
+<div class="app">
+
+  <!-- Sidebar -->
+  <aside class="sidebar" id="sidebar">
+    <div class="sidebar-brand">
+      <a href="/" style="display:flex;align-items:center;gap:12px;text-decoration:none;color:inherit;">
+        <div class="brand-mark">SAE</div>
+        <div class="brand-text">Social Auto Engine</div>
+      </a>
+    </div>
+
+    <nav class="sidebar-section">
+      <div class="sidebar-section-label">Workspace</div>
+      <a class="nav-item {% if active_nav == 'inbox' %}active{% endif %}" href="/">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M22 12h-6l-2 3h-4l-2-3H2" stroke-linecap="round" stroke-linejoin="round"/><path d="M5.45 5.11L2 12v6a2 2 0 002 2h16a2 2 0 002-2v-6l-3.45-6.89A2 2 0 0016.76 4H7.24a2 2 0 00-1.79 1.11z" stroke-linecap="round" stroke-linejoin="round"/></svg>
+        Inbox
+        {% if stats and stats.get('pending', 0) %}
+          <span class="badge">{{ stats.get('pending', 0) }}</span>
+        {% endif %}
+      </a>
+      <a class="nav-item {% if active_nav == 'calendar' %}active{% endif %}" href="/calendar">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><rect x="3" y="4" width="18" height="18" rx="2" stroke-linecap="round" stroke-linejoin="round"/><path d="M16 2v4M8 2v4M3 10h18" stroke-linecap="round" stroke-linejoin="round"/></svg>
+        Calendar
+        {% if stats and stats.get('scheduled', 0) %}
+          <span class="badge">{{ stats.get('scheduled', 0) }}</span>
+        {% endif %}
+      </a>
+      <a class="nav-item {% if active_nav == 'published' %}active{% endif %}" href="/published">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M22 2L11 13M22 2l-7 20-4-9-9-4 20-7z" stroke-linecap="round" stroke-linejoin="round"/></svg>
+        Published
+      </a>
+    </nav>
+
+    <nav class="sidebar-section">
+      <div class="sidebar-section-label">Accounts</div>
+      {% for group in sidebar_groups %}
+      <details class="sidebar-company" open>
+        <summary class="sidebar-company-header">
+          <span class="company-name">{{ group.company }}</span>
+          <svg class="company-chevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" width="14" height="14">
+            <polyline points="6 9 12 15 18 9" stroke-linecap="round" stroke-linejoin="round"/>
+          </svg>
+        </summary>
+        <div class="sidebar-company-body">
+          {% for acct in group.accounts %}
+          <div class="nav-account {% if acct.connected %}connected{% endif %}" data-platform="{{ acct.platform }}">
+            <span class="platform-icon {{ acct.cls }}">{{ acct.icon }}</span>
+            <span>{{ acct.label }}</span>
+            <span class="status-dot"></span>
+          </div>
+          {% endfor %}
+        </div>
+      </details>
+      {% endfor %}
+    </nav>
+
+    <nav class="sidebar-section sidebar-footer">
+      <a class="nav-item {% if active_nav == 'settings' %}active{% endif %}" href="/settings">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><circle cx="12" cy="12" r="3" stroke-linecap="round" stroke-linejoin="round"/><path d="M19.4 15a1.65 1.65 0 00.33 1.82l.06.06a2 2 0 01-2.83 2.83l-.06-.06a1.65 1.65 0 00-1.82-.33 1.65 1.65 0 00-1 1.51V21a2 2 0 01-4 0v-.09A1.65 1.65 0 009 19.4a1.65 1.65 0 00-1.82.33l-.06.06a2 2 0 01-2.83-2.83l.06-.06a1.65 1.65 0 00.33-1.82 1.65 1.65 0 00-1.51-1H3a2 2 0 010-4h.09A1.65 1.65 0 004.6 9a1.65 1.65 0 00-.33-1.82l-.06-.06a2 2 0 012.83-2.83l.06.06a1.65 1.65 0 001.82.33H9a1.65 1.65 0 001-1.51V3a2 2 0 014 0v.09a1.65 1.65 0 001 1.51 1.65 1.65 0 001.82-.33l.06-.06a2 2 0 012.83 2.83l-.06.06a1.65 1.65 0 00-.33 1.82V9a1.65 1.65 0 001.51 1H21a2 2 0 010 4h-.09a1.65 1.65 0 00-1.51 1z" stroke-linecap="round" stroke-linejoin="round"/></svg>
+        Settings
+      </a>
+      {% if auth_active %}
+      <form method="post" action="/logout" style="margin:0;">
+        <button type="submit" class="logout-btn">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M9 21H5a2 2 0 01-2-2V5a2 2 0 012-2h4" stroke-linecap="round" stroke-linejoin="round"/><polyline points="16 17 21 12 16 7" stroke-linecap="round" stroke-linejoin="round"/><line x1="21" y1="12" x2="9" y2="12" stroke-linecap="round" stroke-linejoin="round"/></svg>
+          Sign out
+        </button>
+      </form>
+      {% endif %}
+    </nav>
+  </aside>
+
+  <!-- Main -->
+  <main class="main">
+
+    <header class="topbar">
+      <div style="display:flex;align-items:center;">
+        <button class="mobile-nav-toggle btn btn-ghost btn-icon" aria-label="Menu"
+                onclick="document.getElementById('sidebar').classList.toggle('sidebar-open')">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M4 6h16M4 12h16M4 18h16" stroke-linecap="round" stroke-linejoin="round"/></svg>
+        </button>
+        <div class="breadcrumb">
+          <a class="breadcrumb-link" href="/">Workspace</a>
+          <span class="breadcrumb-sep">/</span>
+          <span class="breadcrumb-current">{% block breadcrumb %}Inbox{% endblock %}</span>
+        </div>
+      </div>
+      <div class="topbar-actions">
+        {% block topbar_actions %}{% endblock %}
+      </div>
+    </header>
+
+    <div class="page">
+      {% block content %}{% endblock %}
+    </div>
+
+  </main>
+
+</div>
+
+{% include "_toast.html" %}
+{% block scripts %}{% endblock %}
+
+</body>
+</html>

--- a/dashboard/templates/_base_login.html
+++ b/dashboard/templates/_base_login.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>{% block title %}Social Auto Engine{% endblock %}</title>
+  <link rel="icon" type="image/svg+xml" href="/static/favicon.svg">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="/static/styles.css">
+</head>
+<body>
+
+<div class="login-page">
+  {% block content %}{% endblock %}
+</div>
+
+</body>
+</html>

--- a/dashboard/templates/_columns.html
+++ b/dashboard/templates/_columns.html
@@ -1,27 +1,31 @@
 <div id="content">
 
   {# ─── PENDING ────────────────────────────────────────── #}
-  {% if pending %}
+  {% set ns = namespace(group_post_count=0) %}
+  {% for grp in pending_groups | default([]) %}{% set ns.group_post_count = ns.group_post_count + grp|length %}{% endfor %}
+  {% set total_pending = (pending|length) + ns.group_post_count %}
+
+  {% if total_pending %}
   <section class="section">
     <div class="section-header">
       <h2 class="section-title">
         <span class="stat-dot s-pending"></span>
         Awaiting approval
-        <span class="section-count">{{ pending|length }}</span>
+        <span class="section-count">{{ total_pending }}</span>
       </h2>
     </div>
 
-    {% if pending|length > 1 %}
+    {% if total_pending > 1 %}
     <div class="bulk-bar">
       <div class="bulk-bar-text">
-        <strong>{{ pending|length }}</strong>
+        <strong>{{ total_pending }}</strong>
         posts ready to publish
       </div>
       <button class="btn btn-primary btn-sm"
               hx-post="/approve-all"
               hx-target="#content"
               hx-swap="outerHTML"
-              hx-confirm="Publish all {{ pending|length }} pending posts? This is the real thing.">
+              hx-confirm="Publish all {{ total_pending }} pending posts? This is the real thing.">
         <svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M22 11.08V12a10 10 0 11-5.93-9.14" stroke-linecap="round" stroke-linejoin="round"/><polyline points="22 4 12 14.01 9 11.01" stroke-linecap="round" stroke-linejoin="round"/></svg>
         Approve all
       </button>
@@ -29,6 +33,51 @@
     {% endif %}
 
     <div class="post-list">
+      {# ─── Grouped (broadcast) pending posts render as one card ─── #}
+      {% for grp in pending_groups | default([]) %}
+        {% set first = grp[0] %}
+        <div class="post-row post-group pending">
+          <div class="post-status">
+            <span class="post-status-dot s-pending"></span>
+            <span class="post-status-label">Broadcast</span>
+            <span class="post-group-count">{{ grp|length }} platforms</span>
+          </div>
+          <div class="post-message">{{ first.message }}</div>
+          <div class="post-group-platforms">
+            {% for p in grp %}
+              {% set cls = {'facebook':'fb','instagram':'ig','whatsapp':'wa','threads':'th','linkedin':'li','tiktok':'tt','youtube':'yt','x':'x'}.get(p.platform, 'fb') %}
+              {% set icon = {'facebook':'f','instagram':'IG','whatsapp':'W','threads':'@','linkedin':'in','tiktok':'TT','youtube':'YT','x':'\U0001d54f'}.get(p.platform, 'f') %}
+              <span class="post-group-platform" data-tip="{{ p.account_name }}">
+                <span class="platform-icon {{ cls }}" style="width:14px;height:14px;font-size:8px;">{{ icon }}</span>
+                <span>{{ p.platform | title }}</span>
+              </span>
+            {% endfor %}
+          </div>
+          <div class="post-meta">
+            <span data-tip="{{ first.created_at }}" data-tip-place="bottom">{{ first.created_at | time_ago }}</span>
+          </div>
+          <div class="post-actions">
+            <button class="btn btn-success btn-sm"
+                    data-tip="Approve & publish to all {{ grp|length }} platforms"
+                    hx-post="/approve-group/{{ first.group_id }}"
+                    hx-target="#content"
+                    hx-swap="outerHTML"
+                    hx-confirm="Publish to all {{ grp|length }} platforms? Going live now.">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><polyline points="20 6 9 17 4 12" stroke-linecap="round" stroke-linejoin="round"/></svg>
+              Publish all
+            </button>
+            <button class="btn btn-ghost btn-sm"
+                    data-tip="Reject all in this broadcast"
+                    hx-post="/reject-group/{{ first.group_id }}"
+                    hx-target="#content"
+                    hx-swap="outerHTML">
+              Reject all
+            </button>
+          </div>
+        </div>
+      {% endfor %}
+
+      {# ─── Single (non-grouped) pending posts ─── #}
       {% for p in pending %}
         <div class="post-row pending">
           <div class="post-status">
@@ -37,13 +86,9 @@
           </div>
           <div class="post-message">{{ p.message }}</div>
           <div class="post-meta">
-            {% if p.platform == 'instagram' %}
-              <span class="platform-icon ig" style="width:14px;height:14px;font-size:7px;">IG</span>
-            {% elif p.platform == 'whatsapp' %}
-              <span class="platform-icon wa" style="width:14px;height:14px;font-size:8px;">W</span>
-            {% else %}
-              <span class="platform-icon fb" style="width:14px;height:14px;font-size:8px;">f</span>
-            {% endif %}
+            {% set cls = {'facebook':'fb','instagram':'ig','whatsapp':'wa','threads':'th','linkedin':'li','tiktok':'tt','youtube':'yt','x':'x'}.get(p.platform, 'fb') %}
+            {% set icon = {'facebook':'f','instagram':'IG','whatsapp':'W','threads':'@','linkedin':'in','tiktok':'TT','youtube':'YT','x':'\U0001d54f'}.get(p.platform, 'f') %}
+            <span class="platform-icon {{ cls }}" style="width:14px;height:14px;font-size:8px;">{{ icon }}</span>
             <span>{{ p.account_name }}{% if p.recipient %} → {{ p.recipient }}{% endif %}</span>
             <span>·</span>
             <span data-tip="{{ p.created_at }}" data-tip-place="bottom">{{ p.created_at | time_ago }}</span>

--- a/dashboard/templates/_schedules.html
+++ b/dashboard/templates/_schedules.html
@@ -1,0 +1,87 @@
+<div id="schedules">
+  <section class="section">
+    <div class="section-header">
+      <h2 class="section-title">
+        <span class="stat-dot s-pending"></span>
+        Scheduled posts
+        <span class="section-count">{{ scheduled|length }}</span>
+      </h2>
+    </div>
+
+    {% if scheduled %}
+      <div class="post-list">
+        {% for p in scheduled %}
+          <div class="post-row pending">
+            <div class="post-status">
+              <span class="post-status-dot s-pending"></span>
+              <span class="post-status-label">Scheduled</span>
+            </div>
+            <div class="post-message">{{ p.message }}</div>
+            <div class="post-meta">
+              {% if p.platform == 'instagram' %}
+                <span class="platform-icon ig" style="width:14px;height:14px;font-size:7px;">IG</span>
+              {% elif p.platform == 'whatsapp' %}
+                <span class="platform-icon wa" style="width:14px;height:14px;font-size:8px;">W</span>
+              {% elif p.platform == 'threads' %}
+                <span class="platform-icon th" style="width:14px;height:14px;font-size:8px;">@</span>
+              {% else %}
+                <span class="platform-icon fb" style="width:14px;height:14px;font-size:8px;">f</span>
+              {% endif %}
+              <span>{{ p.account_name }}</span>
+              <span>·</span>
+              <span data-tip="{{ p.scheduled_for }}">{{ p.scheduled_for | time_ago }}</span>
+            </div>
+            <div class="post-actions">
+              <button class="btn btn-ghost btn-sm"
+                      data-tip="Cancel schedule — return to pending"
+                      hx-post="/unschedule/{{ p.id }}"
+                      hx-target="#content"
+                      hx-swap="outerHTML">
+                Unschedule
+              </button>
+            </div>
+          </div>
+        {% endfor %}
+      </div>
+    {% else %}
+      <div class="post-list">
+        <div class="empty">
+          <div class="empty-icon">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14" stroke-linecap="round" stroke-linejoin="round"/></svg>
+          </div>
+          <div class="empty-title">No scheduled posts</div>
+          <div class="empty-body">Schedule a pending post and it will appear here with a countdown.</div>
+        </div>
+      </div>
+    {% endif %}
+  </section>
+
+  {% if jobs %}
+  <section class="section">
+    <div class="section-header">
+      <h2 class="section-title">
+        <span class="stat-dot s-neutral"></span>
+        APScheduler jobs
+        <span class="section-count">{{ jobs|length }}</span>
+      </h2>
+    </div>
+    <div class="post-list">
+      {% for j in jobs %}
+        <div class="post-row">
+          <div class="post-status">
+            <span class="post-status-dot s-neutral"></span>
+            <span class="post-status-label">Job</span>
+          </div>
+          <div class="post-message">{{ j.id }}</div>
+          <div class="post-meta">
+            <span>Post #{{ j.post_id }}</span>
+            <span>·</span>
+            <span>{{ j.next_run_time | time_ago if j.next_run_time else 'paused' }}</span>
+          </div>
+          <div class="post-actions"></div>
+        </div>
+      {% endfor %}
+    </div>
+  </section>
+  {% endif %}
+</div>

--- a/dashboard/templates/calendar.html
+++ b/dashboard/templates/calendar.html
@@ -1,0 +1,235 @@
+{% extends "_base.html" %}
+{% block title %}Social Auto Engine — Calendar{% endblock %}
+{% block breadcrumb %}Calendar{% endblock %}
+
+{% block content %}
+
+  <div class="page-header">
+    <div>
+      <h1 class="page-title">Content Calendar</h1>
+      <p class="page-description">Drag posts to reschedule. Click empty slots to compose.</p>
+    </div>
+    <div class="cal-nav">
+      <button class="btn btn-ghost btn-sm" id="calPrev" aria-label="Previous week">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M15 18l-6-6 6-6" stroke-linecap="round" stroke-linejoin="round"/></svg>
+      </button>
+      <button class="btn btn-secondary btn-sm" id="calToday">Today</button>
+      <button class="btn btn-ghost btn-sm" id="calNext" aria-label="Next week">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M9 18l6-6-6-6" stroke-linecap="round" stroke-linejoin="round"/></svg>
+      </button>
+      <span class="cal-range" id="calRange"></span>
+    </div>
+  </div>
+
+  <div class="cal-grid" id="calGrid">
+    <!-- Rendered by JS -->
+  </div>
+
+{% endblock %}
+
+{% block scripts %}
+<script>
+(function() {
+  /* ── State ──────────────────────────────────── */
+  const HOURS = Array.from({length: 16}, (_, i) => i + 6); // 6am–9pm
+  let weekStart = getMonday(new Date());
+  let posts = {{ posts_json | safe }};
+
+  /* ── Helpers ────────────────────────────────── */
+  function getMonday(d) {
+    const dt = new Date(d);
+    const day = dt.getDay();
+    const diff = dt.getDate() - day + (day === 0 ? -6 : 1);
+    dt.setDate(diff);
+    dt.setHours(0,0,0,0);
+    return dt;
+  }
+
+  function addDays(d, n) {
+    const dt = new Date(d);
+    dt.setDate(dt.getDate() + n);
+    return dt;
+  }
+
+  function fmtDate(d) {
+    return d.toISOString().slice(0, 10);
+  }
+
+  function fmtShort(d) {
+    return d.toLocaleDateString('en-US', { weekday: 'short', month: 'short', day: 'numeric' });
+  }
+
+  function fmtRange(start) {
+    const end = addDays(start, 6);
+    const sm = start.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+    const em = end.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
+    return sm + ' – ' + em;
+  }
+
+  function isToday(d) {
+    const now = new Date();
+    return d.getFullYear() === now.getFullYear() && d.getMonth() === now.getMonth() && d.getDate() === now.getDate();
+  }
+
+  function getPostTime(p) {
+    return p.scheduled_for || p.published_at || p.created_at || '';
+  }
+
+  function getPostHour(p) {
+    const t = getPostTime(p);
+    if (!t) return 9;
+    const h = parseInt(t.slice(11, 13), 10);
+    return isNaN(h) ? 9 : h;
+  }
+
+  function statusClass(s) {
+    return s === 'published' ? 'cal-ev-published' :
+           s === 'scheduled' ? 'cal-ev-scheduled' :
+           s === 'pending' ? 'cal-ev-pending' :
+           s === 'failed' ? 'cal-ev-failed' : '';
+  }
+
+  function statusIcon(s) {
+    if (s === 'published') return '<span class="cal-dot s-success"></span>';
+    if (s === 'scheduled') return '<span class="cal-dot s-pending"></span>';
+    if (s === 'pending') return '<span class="cal-dot s-pending"></span>';
+    if (s === 'failed') return '<span class="cal-dot s-error"></span>';
+    return '';
+  }
+
+  /* ── Render ─────────────────────────────────── */
+  function render() {
+    const grid = document.getElementById('calGrid');
+    document.getElementById('calRange').textContent = fmtRange(weekStart);
+
+    // Build header
+    let html = '<div class="cal-header"><div class="cal-time-gutter"></div>';
+    for (let d = 0; d < 7; d++) {
+      const day = addDays(weekStart, d);
+      const today = isToday(day) ? ' cal-today' : '';
+      html += '<div class="cal-day-header' + today + '">';
+      html += '<span class="cal-day-name">' + day.toLocaleDateString('en-US', {weekday: 'short'}) + '</span>';
+      html += '<span class="cal-day-num">' + day.getDate() + '</span>';
+      html += '</div>';
+    }
+    html += '</div>';
+
+    // Build body (scrollable)
+    html += '<div class="cal-body">';
+    for (const h of HOURS) {
+      html += '<div class="cal-row">';
+      html += '<div class="cal-time-gutter"><span>' + (h % 12 || 12) + (h < 12 ? 'a' : 'p') + '</span></div>';
+      for (let d = 0; d < 7; d++) {
+        const day = addDays(weekStart, d);
+        const dateStr = fmtDate(day);
+        const today = isToday(day) ? ' cal-today-col' : '';
+        html += '<div class="cal-cell' + today + '" data-date="' + dateStr + '" data-hour="' + h + '">';
+
+        // Place posts in this cell
+        const cellPosts = posts.filter(p => {
+          const t = getPostTime(p);
+          return t && t.slice(0, 10) === dateStr && getPostHour(p) === h;
+        });
+        for (const p of cellPosts) {
+          html += '<div class="cal-event ' + statusClass(p.status) + '" draggable="true" data-id="' + p.id + '">';
+          html += statusIcon(p.status);
+          html += '<span class="cal-ev-text">' + escHtml(p.message.slice(0, 50)) + '</span>';
+          html += '</div>';
+        }
+
+        html += '</div>';
+      }
+      html += '</div>';
+    }
+    html += '</div>';
+
+    grid.innerHTML = html;
+    attachDragHandlers();
+  }
+
+  function escHtml(s) {
+    const d = document.createElement('div');
+    d.textContent = s;
+    return d.innerHTML;
+  }
+
+  /* ── Drag & Drop ────────────────────────────── */
+  let dragPostId = null;
+
+  function attachDragHandlers() {
+    document.querySelectorAll('.cal-event').forEach(el => {
+      el.addEventListener('dragstart', e => {
+        dragPostId = el.dataset.id;
+        el.classList.add('cal-dragging');
+        e.dataTransfer.effectAllowed = 'move';
+      });
+      el.addEventListener('dragend', () => {
+        el.classList.remove('cal-dragging');
+        dragPostId = null;
+      });
+    });
+
+    document.querySelectorAll('.cal-cell').forEach(cell => {
+      cell.addEventListener('dragover', e => {
+        e.preventDefault();
+        e.dataTransfer.dropEffect = 'move';
+        cell.classList.add('cal-drop-target');
+      });
+      cell.addEventListener('dragleave', () => {
+        cell.classList.remove('cal-drop-target');
+      });
+      cell.addEventListener('drop', e => {
+        e.preventDefault();
+        cell.classList.remove('cal-drop-target');
+        if (!dragPostId) return;
+
+        const date = cell.dataset.date;
+        const hour = cell.dataset.hour.padStart(2, '0');
+        const isoTime = date + 'T' + hour + ':00:00Z';
+
+        // Submit reschedule via HTMX-style fetch
+        const form = new FormData();
+        form.append('at', isoTime);
+        fetch('/schedule/' + dragPostId, { method: 'POST', body: form })
+          .then(r => {
+            if (r.ok) {
+              // Update local state and re-render
+              const post = posts.find(p => p.id == dragPostId);
+              if (post) {
+                post.scheduled_for = isoTime;
+                post.status = 'scheduled';
+              }
+              render();
+              showToast('success', 'Rescheduled to ' + date + ' at ' + hour + ':00 UTC');
+            } else {
+              r.text().then(t => showToast('error', 'Failed: ' + t.slice(0, 100)));
+            }
+          })
+          .catch(() => showToast('error', 'Network error'));
+      });
+    });
+  }
+
+  function showToast(kind, message) {
+    document.body.dispatchEvent(new CustomEvent('toast', { detail: { kind, message } }));
+  }
+
+  /* ── Navigation ─────────────────────────────── */
+  document.getElementById('calPrev').onclick = () => { weekStart = addDays(weekStart, -7); fetchAndRender(); };
+  document.getElementById('calNext').onclick = () => { weekStart = addDays(weekStart, 7); fetchAndRender(); };
+  document.getElementById('calToday').onclick = () => { weekStart = getMonday(new Date()); fetchAndRender(); };
+
+  function fetchAndRender() {
+    const start = fmtDate(weekStart) + 'T00:00:00';
+    const end = fmtDate(addDays(weekStart, 7)) + 'T00:00:00';
+    fetch('/api/calendar?start=' + encodeURIComponent(start) + '&end=' + encodeURIComponent(end))
+      .then(r => r.json())
+      .then(data => { posts = data; render(); })
+      .catch(() => render());
+  }
+
+  /* ── Init ───────────────────────────────────── */
+  render();
+})();
+</script>
+{% endblock %}

--- a/dashboard/templates/index.html
+++ b/dashboard/templates/index.html
@@ -1,298 +1,217 @@
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Social Auto Engine — Inbox</title>
-  <link rel="icon" type="image/svg+xml" href="/static/favicon.svg">
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="/static/styles.css">
-  <script src="https://unpkg.com/htmx.org@2.0.4" integrity="sha384-HGfztofotfshcF7+8n44JQL2oJmowVChPTg48S+jvZoztPfvwD79OC/LTtG6dMp+" crossorigin="anonymous"></script>
-</head>
-<body>
+{% extends "_base.html" %}
+{% block title %}Social Auto Engine — Inbox{% endblock %}
 
-<div class="app">
+{% block content %}
 
-  <!-- Sidebar -->
-  <aside class="sidebar">
-    <div class="sidebar-brand">
-      <div class="brand-mark">SAE</div>
-      <div class="brand-text">Social Auto Engine</div>
+  <div class="page-header">
+    <div>
+      <h1 class="page-title">Inbox</h1>
+      <p class="page-description">Review, approve, and schedule posts. Nothing publishes without your say.</p>
+    </div>
+    <button class="btn btn-primary" onclick="toggleCompose()" id="composeToggle">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M12 5v14M5 12h14" stroke-linecap="round" stroke-linejoin="round"/></svg>
+      New post
+    </button>
+  </div>
+
+  <!-- Stats strip — compact single row -->
+  <div class="stats-strip">
+    <div class="strip-stat">
+      <span class="stat-dot s-pending"></span>
+      <span class="strip-label">Pending</span>
+      <span class="strip-value">{{ stats.get('pending', 0) }}</span>
+    </div>
+    <div class="strip-stat">
+      <span class="stat-dot s-success"></span>
+      <span class="strip-label">Published</span>
+      <span class="strip-value">{{ stats.get('published', 0) }}</span>
+    </div>
+    <div class="strip-stat">
+      <span class="stat-dot s-pending"></span>
+      <span class="strip-label">Scheduled</span>
+      <span class="strip-value">{{ stats.get('scheduled', 0) }}</span>
+    </div>
+    <div class="strip-stat">
+      <span class="stat-dot s-error"></span>
+      <span class="strip-label">Failed</span>
+      <span class="strip-value">{{ stats.get('failed', 0) }}</span>
+    </div>
+  </div>
+
+  <!-- Compose (collapsed by default) -->
+  <section class="compose" id="composeSection" style="display:none;">
+    <div class="compose-mode-tabs">
+      <button type="button" class="compose-tab active" data-mode="broadcast" onclick="setComposeMode('broadcast')">
+        Broadcast
+      </button>
+      <button type="button" class="compose-tab" data-mode="direct" onclick="setComposeMode('direct')">
+        Direct message (WhatsApp)
+      </button>
     </div>
 
-    <nav class="sidebar-section">
-      <div class="sidebar-section-label">Workspace</div>
-      <div class="nav-item active">
-        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M22 12h-6l-2 3h-4l-2-3H2" stroke-linecap="round" stroke-linejoin="round"/><path d="M5.45 5.11L2 12v6a2 2 0 002 2h16a2 2 0 002-2v-6l-3.45-6.89A2 2 0 0016.76 4H7.24a2 2 0 00-1.79 1.11z" stroke-linecap="round" stroke-linejoin="round"/></svg>
-        Inbox
-        {% if stats.get('pending', 0) %}
-          <span class="badge">{{ stats.get('pending', 0) }}</span>
-        {% endif %}
-      </div>
-      <div class="nav-item">
-        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M22 2L11 13M22 2l-7 20-4-9-9-4 20-7z" stroke-linecap="round" stroke-linejoin="round"/></svg>
-        Published
-      </div>
-      <div class="nav-item">
-        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><rect x="3" y="4" width="18" height="18" rx="2" stroke-linecap="round" stroke-linejoin="round"/><path d="M16 2v4M8 2v4M3 10h18" stroke-linecap="round" stroke-linejoin="round"/></svg>
-        Scheduled
-      </div>
-      <div class="nav-item">
-        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M3 3v18h18" stroke-linecap="round" stroke-linejoin="round"/><path d="M7 12l3-3 4 4 5-5" stroke-linecap="round" stroke-linejoin="round"/></svg>
-        Analytics
-      </div>
-    </nav>
-
-    <nav class="sidebar-section">
-      <div class="sidebar-section-label">Accounts</div>
-      <div class="nav-account connected">
-        <span class="platform-icon fb">f</span>
-        <span>{{ page.name or 'Hack-Tech' }}</span>
-        <span class="status-dot"></span>
-      </div>
-      <div class="nav-account {% if ig and ig.connected %}connected{% endif %}">
-        <span class="platform-icon ig">IG</span>
-        <span>{% if ig and ig.connected %}@{{ ig.username }}{% else %}Instagram{% endif %}</span>
-        <span class="status-dot"></span>
-      </div>
-      <div class="nav-account">
-        <span class="platform-icon li">in</span>
-        <span>LinkedIn</span>
-        <span class="status-dot"></span>
-      </div>
-      <div class="nav-account">
-        <span class="platform-icon x">𝕏</span>
-        <span>X / Twitter</span>
-        <span class="status-dot"></span>
-      </div>
-      <div class="nav-account">
-        <span class="platform-icon tt">TT</span>
-        <span>TikTok</span>
-        <span class="status-dot"></span>
-      </div>
-      <div class="nav-account {% if wa and wa.connected %}connected{% endif %}">
-        <span class="platform-icon wa">W</span>
-        <span>{% if wa and wa.connected %}{{ wa.display_phone_number }}{% else %}WhatsApp{% endif %}</span>
-        <span class="status-dot"></span>
-      </div>
-      <div class="nav-account {% if threads and threads.connected %}connected{% endif %}">
-        <span class="platform-icon th">@</span>
-        <span>{% if threads and threads.connected %}@{{ threads.username }}{% else %}Threads{% endif %}</span>
-        <span class="status-dot"></span>
-      </div>
-    </nav>
-
-    <nav class="sidebar-section sidebar-footer">
-      <a class="nav-item" href="/settings">
-        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><circle cx="12" cy="12" r="3" stroke-linecap="round" stroke-linejoin="round"/><path d="M19.4 15a1.65 1.65 0 00.33 1.82l.06.06a2 2 0 01-2.83 2.83l-.06-.06a1.65 1.65 0 00-1.82-.33 1.65 1.65 0 00-1 1.51V21a2 2 0 01-4 0v-.09A1.65 1.65 0 009 19.4a1.65 1.65 0 00-1.82.33l-.06.06a2 2 0 01-2.83-2.83l.06-.06a1.65 1.65 0 00.33-1.82 1.65 1.65 0 00-1.51-1H3a2 2 0 010-4h.09A1.65 1.65 0 004.6 9a1.65 1.65 0 00-.33-1.82l-.06-.06a2 2 0 012.83-2.83l.06.06a1.65 1.65 0 001.82.33H9a1.65 1.65 0 001-1.51V3a2 2 0 014 0v.09a1.65 1.65 0 001 1.51 1.65 1.65 0 001.82-.33l.06-.06a2 2 0 012.83 2.83l-.06.06a1.65 1.65 0 00-.33 1.82V9a1.65 1.65 0 001.51 1H21a2 2 0 010 4h-.09a1.65 1.65 0 00-1.51 1z" stroke-linecap="round" stroke-linejoin="round"/></svg>
-        Settings
-      </a>
-      <div class="nav-item">
-        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><circle cx="12" cy="12" r="10" stroke-linecap="round" stroke-linejoin="round"/><path d="M9.09 9a3 3 0 015.83 1c0 2-3 3-3 3M12 17h.01" stroke-linecap="round" stroke-linejoin="round"/></svg>
-        Docs
-      </div>
-    </nav>
-  </aside>
-
-  <!-- Main -->
-  <main class="main">
-
-    <header class="topbar">
-      <div style="display:flex;align-items:center;">
-        <button class="mobile-nav-toggle btn btn-ghost btn-icon" aria-label="Menu">
-          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M4 6h16M4 12h16M4 18h16" stroke-linecap="round" stroke-linejoin="round"/></svg>
-        </button>
-        <div class="breadcrumb">
-          <span class="breadcrumb-link">Workspace</span>
-          <span class="breadcrumb-sep">/</span>
-          <span class="breadcrumb-current">Inbox</span>
-        </div>
-      </div>
-      <div class="topbar-actions">
-        <div class="account-switcher">
-          <span class="account-avatar">HT</span>
-          <span>{{ page.name or 'Hack-Tech' }}</span>
-          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M6 9l6 6 6-6" stroke-linecap="round" stroke-linejoin="round"/></svg>
-        </div>
-        <button class="btn btn-ghost btn-sm" data-tip="Search" data-tip-place="bottom">
-          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><circle cx="11" cy="11" r="8" stroke-linecap="round" stroke-linejoin="round"/><path d="M21 21l-4.35-4.35" stroke-linecap="round" stroke-linejoin="round"/></svg>
-          <kbd>⌘K</kbd>
-        </button>
-      </div>
-    </header>
-
-    <div class="page">
-
-      <div class="page-header">
-        <div>
-          <h1 class="page-title">Inbox</h1>
-          <p class="page-description">Drafts and scheduled posts. Nothing publishes without your approval.</p>
-        </div>
-      </div>
-
-      <!-- Stats -->
-      <section class="stats">
-        <div class="stat">
-          <div class="stat-label"><span class="stat-dot s-pending"></span>Pending</div>
-          <div class="stat-value">{{ stats.get('pending', 0) }}</div>
-        </div>
-        <div class="stat">
-          <div class="stat-label"><span class="stat-dot s-success"></span>Published</div>
-          <div class="stat-value">{{ stats.get('published', 0) }}</div>
-        </div>
-        <div class="stat">
-          <div class="stat-label"><span class="stat-dot s-error"></span>Failed</div>
-          <div class="stat-value">{{ stats.get('failed', 0) }}</div>
-        </div>
-        <div class="stat">
-          <div class="stat-label"><span class="stat-dot s-neutral"></span>Rejected</div>
-          <div class="stat-value">{{ stats.get('rejected', 0) }}</div>
-        </div>
-      </section>
-
-      <!-- Compose -->
-      <section class="compose">
-        <div class="compose-header">
-          <div class="compose-title">New post</div>
-          <div class="platform-toggle">
-            <label>
-              <input type="radio" name="platform-toggle" value="facebook" checked
-                     onchange="setPlatform('facebook')">
-              <span class="pt-pill">
-                <span class="platform-icon fb">f</span>
-                Facebook
-              </span>
+    {# ─── BROADCAST FORM ─────────────────────────────────── #}
+    <form id="broadcastForm" class="compose-form" hx-post="/compose" hx-target="#content" hx-swap="outerHTML"
+          hx-on:htmx:after-request="if(event.detail.successful){this.reset();document.getElementById('bccCount').textContent='0';document.getElementById('bImgRow').style.display='none';toggleCompose()}">
+      <div class="compose-platforms">
+        <div class="compose-platforms-label">Publish to</div>
+        <div class="compose-platforms-groups">
+          <div class="compose-platform-group">
+            <div class="cpg-name">Meta</div>
+            <label class="cp-check">
+              <input type="checkbox" name="platforms" value="facebook" checked>
+              <span class="platform-icon fb">f</span> Facebook
             </label>
-            <label>
-              <input type="radio" name="platform-toggle" value="instagram"
-                     onchange="setPlatform('instagram')"
+            <label class="cp-check {% if not ig or not ig.connected %}disabled{% endif %}">
+              <input type="checkbox" name="platforms" value="instagram"
                      {% if not ig or not ig.connected %}disabled{% endif %}>
-              <span class="pt-pill">
-                <span class="platform-icon ig">IG</span>
-                Instagram
-                {% if ig and ig.connected %}<span class="pt-handle">@{{ ig.username }}</span>{% endif %}
-              </span>
+              <span class="platform-icon ig">IG</span> Instagram
             </label>
-            <label>
-              <input type="radio" name="platform-toggle" value="whatsapp"
-                     onchange="setPlatform('whatsapp')"
-                     {% if not wa or not wa.connected %}disabled{% endif %}>
-              <span class="pt-pill">
-                <span class="platform-icon wa">W</span>
-                WhatsApp
-                {% if wa and wa.connected %}<span class="pt-handle">{{ wa.display_phone_number }}</span>{% endif %}
-              </span>
-            </label>
-            <label>
-              <input type="radio" name="platform-toggle" value="threads"
-                     onchange="setPlatform('threads')"
+            <label class="cp-check {% if not threads or not threads.connected %}disabled{% endif %}">
+              <input type="checkbox" name="platforms" value="threads"
                      {% if not threads or not threads.connected %}disabled{% endif %}>
-              <span class="pt-pill">
-                <span class="platform-icon th">@</span>
-                Threads
-                {% if threads and threads.connected %}<span class="pt-handle">@{{ threads.username }}</span>{% endif %}
-              </span>
+              <span class="platform-icon th">@</span> Threads
+            </label>
+          </div>
+          <div class="compose-platform-group">
+            <div class="cpg-name">LinkedIn</div>
+            <label class="cp-check {% if not linkedin or not linkedin.connected %}disabled{% endif %}">
+              <input type="checkbox" name="platforms" value="linkedin"
+                     {% if not linkedin or not linkedin.connected %}disabled{% endif %}>
+              <span class="platform-icon li">in</span> LinkedIn
+            </label>
+          </div>
+          <div class="compose-platform-group">
+            <div class="cpg-name">TikTok</div>
+            <label class="cp-check disabled">
+              <input type="checkbox" disabled>
+              <span class="platform-icon tt">TT</span> TikTok <span class="cp-soon">(soon)</span>
+            </label>
+          </div>
+          <div class="compose-platform-group">
+            <div class="cpg-name">YouTube</div>
+            <label class="cp-check disabled">
+              <input type="checkbox" disabled>
+              <span class="platform-icon yt">YT</span> YouTube <span class="cp-soon">(soon)</span>
+            </label>
+          </div>
+          <div class="compose-platform-group">
+            <div class="cpg-name">X</div>
+            <label class="cp-check disabled">
+              <input type="checkbox" disabled>
+              <span class="platform-icon x">𝕏</span> X / Twitter <span class="cp-soon">(soon)</span>
             </label>
           </div>
         </div>
-        <form id="composeForm" hx-post="/compose" hx-target="#content" hx-swap="outerHTML" hx-on:htmx:after-request="if(event.detail.successful){document.getElementById('msg').value='';document.getElementById('img').value='';document.getElementById('cc').textContent='0';document.getElementById('imgRow').style.display='none'}">
-          <input type="hidden" name="platform" id="platformInput" value="facebook">
-          <div class="compose-body">
-            <textarea
-              id="msg"
-              name="message"
-              placeholder="What's on your mind? Drafts go to the approval queue — nothing publishes until you click Approve."
-              oninput="document.getElementById('cc').textContent=this.value.length"
-              required
-            ></textarea>
-            <div id="imgRow" class="img-row" style="display:none;">
-              <span class="img-label">Image URL</span>
-              <input type="url" name="image_url" id="img"
-                     placeholder="https://example.com/image.jpg"
-                     class="img-input">
-            </div>
+      </div>
 
-            <div id="waRow" class="img-row" style="display:none; gap: var(--sp-3);">
-              <span class="img-label">To</span>
-              <input type="tel" name="recipient" id="recipient"
-                     placeholder="+972526139179 (E.164)"
-                     class="img-input" style="flex: 0 1 200px;">
-              <span class="img-label" style="border-left: 1px solid var(--border); padding-left: var(--sp-3);">Template</span>
-              <select name="template_name" id="template_name" class="img-input wa-select">
-                <option value="">Free-form (24h window only)</option>
-                {% if wa_templates %}
-                  {% for t in wa_templates %}
-                    <option value="{{ t.name }}">{{ t.name }} ({{ t.language }})</option>
-                  {% endfor %}
-                {% endif %}
-              </select>
-            </div>
-          </div>
-          <div class="compose-footer">
-            <div class="compose-toolbar">
-              <button type="button" data-tip="Add image" data-tip-place="bottom">
-                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><rect x="3" y="3" width="18" height="18" rx="2" stroke-linecap="round" stroke-linejoin="round"/><circle cx="8.5" cy="8.5" r="1.5" stroke-linecap="round"/><path d="M21 15l-5-5L5 21" stroke-linecap="round" stroke-linejoin="round"/></svg>
-              </button>
-              <button type="button" data-tip="Generate with AI" data-tip-place="bottom">
-                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M12 2l2 7 7 2-7 2-2 7-2-7-7-2 7-2 2-7z" stroke-linecap="round" stroke-linejoin="round"/></svg>
-              </button>
-              <button type="button" data-tip="Schedule for later" data-tip-place="bottom">
-                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><circle cx="12" cy="12" r="10" stroke-linecap="round"/><path d="M12 6v6l4 2" stroke-linecap="round" stroke-linejoin="round"/></svg>
-              </button>
-            </div>
-            <div class="compose-submit">
-              <span class="char-count"><span id="cc">0</span> / 63,206</span>
-              <span class="char-count-divider"></span>
-              <button type="submit" class="btn btn-primary">
-                <svg class="htmx-indicator" viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M21 12a9 9 0 11-6.219-8.56" stroke-linecap="round" stroke-linejoin="round"/></svg>
-                Send for approval
-              </button>
-            </div>
-          </div>
-        </form>
-      </section>
+      <div class="compose-body">
+        <textarea id="bMsg" name="message"
+                  placeholder="What's on your mind? Drafts go to the approval queue."
+                  oninput="document.getElementById('bccCount').textContent=this.value.length"
+                  required></textarea>
+        <div id="bImgRow" class="img-row" style="display:none;">
+          <span class="img-label">Image URL</span>
+          <input type="url" name="image_url" id="bImg" placeholder="https://example.com/image.jpg" class="img-input">
+          <span class="img-hint">Required for Instagram</span>
+        </div>
+      </div>
+      <div class="compose-footer">
+        <div class="compose-toolbar">
+          <button type="button" data-tip="Toggle image" onclick="toggleBroadcastImage()">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><rect x="3" y="3" width="18" height="18" rx="2"/><circle cx="8.5" cy="8.5" r="1.5"/><path d="M21 15l-5-5L5 21"/></svg>
+          </button>
+        </div>
+        <div class="compose-submit">
+          <span class="char-count"><span id="bccCount">0</span></span>
+          <button type="submit" class="btn btn-primary btn-sm">
+            <svg class="htmx-indicator" viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M21 12a9 9 0 11-6.219-8.56" stroke-linecap="round"/></svg>
+            Add to queue
+          </button>
+        </div>
+      </div>
+    </form>
 
-      {% include "_columns.html" %}
+    {# ─── DIRECT MESSAGE FORM (WhatsApp) ─────────────────── #}
+    <form id="directForm" class="compose-form" style="display:none;" hx-post="/compose" hx-target="#content" hx-swap="outerHTML"
+          hx-on:htmx:after-request="if(event.detail.successful){this.reset();document.getElementById('dccCount').textContent='0';toggleCompose()}">
+      <input type="hidden" name="platform" value="whatsapp">
+      <div class="compose-body">
+        <div class="img-row" style="gap: var(--sp-3);">
+          <span class="img-label">To</span>
+          <input type="tel" name="recipient" id="dRecipient" placeholder="+972526139179" class="img-input" style="flex: 0 1 220px;" required>
+          <span class="img-label" style="border-left: 1px solid var(--border); padding-left: var(--sp-3);">Template</span>
+          <select name="template_name" id="dTemplate" class="img-input wa-select">
+            <option value="">Free-form</option>
+            {% if wa_templates %}{% for t in wa_templates %}
+              <option value="{{ t.name }}">{{ t.name }} ({{ t.language }})</option>
+            {% endfor %}{% endif %}
+          </select>
+        </div>
+        <textarea id="dMsg" name="message"
+                  placeholder="Optional body. Template overrides this if both are set."
+                  oninput="document.getElementById('dccCount').textContent=this.value.length"></textarea>
+      </div>
+      <div class="compose-footer">
+        <div class="compose-toolbar"></div>
+        <div class="compose-submit">
+          <span class="char-count"><span id="dccCount">0</span></span>
+          <button type="submit" class="btn btn-primary btn-sm">Add to queue</button>
+        </div>
+      </div>
+    </form>
+  </section>
 
-    </div>
+  {% include "_columns.html" %}
 
-  </main>
+{% endblock %}
 
-</div>
-
-{% include "_toast.html" %}
-
+{% block scripts %}
 <script>
-  const msg = document.getElementById('msg');
-  if (msg) msg.dispatchEvent(new Event('input'));
-
-  function setPlatform(p) {
-    document.getElementById('platformInput').value = p;
-    const imgRow = document.getElementById('imgRow');
-    const imgInput = document.getElementById('img');
-    const waRow = document.getElementById('waRow');
-    const recipientInput = document.getElementById('recipient');
-    const msgInput = document.getElementById('msg');
-
-    imgRow.style.display = (p === 'instagram') ? 'flex' : 'none';
-    imgInput.required = (p === 'instagram');
-
-    waRow.style.display = (p === 'whatsapp') ? 'flex' : 'none';
-    recipientInput.required = (p === 'whatsapp');
-
-    // For WhatsApp, message is optional when a template is selected
-    msgInput.required = (p !== 'whatsapp');
-    if (p === 'whatsapp') {
-      msgInput.placeholder = 'Optional message body. If a template is selected, this is ignored.';
-    } else if (p === 'threads') {
-      msgInput.placeholder = "What's happening? Text posts up to 500 characters. Add an image URL for media posts.";
+  function toggleCompose() {
+    const s = document.getElementById('composeSection');
+    const b = document.getElementById('composeToggle');
+    if (s.style.display === 'none') {
+      s.style.display = '';
+      s.style.animation = 'slideDown 200ms ease-out';
+      b.innerHTML = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M18 6L6 18M6 6l12 12" stroke-linecap="round" stroke-linejoin="round"/></svg> Close';
+      const broadcastVisible = document.getElementById('broadcastForm').style.display !== 'none';
+      const focusTarget = broadcastVisible ? document.getElementById('bMsg') : document.getElementById('dRecipient');
+      if (focusTarget) focusTarget.focus();
     } else {
-      msgInput.placeholder = "What's on your mind? Drafts go to the approval queue — nothing publishes until you click Approve.";
+      s.style.display = 'none';
+      b.innerHTML = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M12 5v14M5 12h14" stroke-linecap="round" stroke-linejoin="round"/></svg> New post';
     }
   }
-</script>
 
-</body>
-</html>
+  function setComposeMode(mode) {
+    const broadcast = document.getElementById('broadcastForm');
+    const direct = document.getElementById('directForm');
+    document.querySelectorAll('.compose-tab').forEach(t => {
+      t.classList.toggle('active', t.dataset.mode === mode);
+    });
+    if (mode === 'broadcast') {
+      broadcast.style.display = '';
+      direct.style.display = 'none';
+      const f = document.getElementById('bMsg'); if (f) f.focus();
+    } else {
+      broadcast.style.display = 'none';
+      direct.style.display = '';
+      const f = document.getElementById('dRecipient'); if (f) f.focus();
+    }
+  }
+
+  function toggleBroadcastImage() {
+    const r = document.getElementById('bImgRow');
+    r.style.display = (r.style.display === 'none') ? 'flex' : 'none';
+  }
+
+  // Auto-show image row when Instagram is checked
+  document.addEventListener('change', (e) => {
+    if (e.target && e.target.name === 'platforms' && e.target.value === 'instagram') {
+      if (e.target.checked) {
+        document.getElementById('bImgRow').style.display = 'flex';
+      }
+    }
+  });
+</script>
+{% endblock %}

--- a/dashboard/templates/login.html
+++ b/dashboard/templates/login.html
@@ -1,0 +1,39 @@
+{% extends "_base_login.html" %}
+{% block title %}Sign in — Social Auto Engine{% endblock %}
+
+{% block content %}
+<div class="login-wrapper">
+  <div class="login-card">
+    <div class="login-brand">
+      <div class="brand-mark" style="width:32px;height:32px;font-size:11px;">SAE</div>
+      <div style="font-size:15px;font-weight:600;letter-spacing:-0.3px;">Social Auto Engine</div>
+    </div>
+
+    <p class="login-subtitle">Enter your dashboard password to continue.</p>
+
+    {% if error %}
+    <div class="login-error">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" style="width:14px;height:14px;flex-shrink:0;stroke-width:2;">
+        <circle cx="12" cy="12" r="10"/><line x1="12" y1="8" x2="12" y2="12"/><line x1="12" y1="16" x2="12.01" y2="16"/>
+      </svg>
+      {{ error }}
+    </div>
+    {% endif %}
+
+    <form method="post" action="/login" class="login-form">
+      <label class="login-label" for="password">Password</label>
+      <input
+        type="password"
+        id="password"
+        name="password"
+        class="login-input"
+        placeholder="Enter password"
+        autocomplete="current-password"
+        autofocus
+        required
+      >
+      <button type="submit" class="btn btn-primary login-submit">Sign in</button>
+    </form>
+  </div>
+</div>
+{% endblock %}

--- a/dashboard/templates/published.html
+++ b/dashboard/templates/published.html
@@ -1,0 +1,59 @@
+{% extends "_base.html" %}
+{% block title %}Social Auto Engine — Published{% endblock %}
+{% block breadcrumb %}Published{% endblock %}
+
+{% block content %}
+
+  <div class="page-header">
+    <div>
+      <h1 class="page-title">Published</h1>
+      <p class="page-description">Everything that went live. Click "view" to open on the platform.</p>
+    </div>
+  </div>
+
+  {% if published %}
+  <div class="post-list">
+    {% for p in published %}
+      <div class="post-row">
+        <div class="post-status">
+          <span class="post-status-dot s-success"></span>
+          {% if p.platform == 'instagram' %}
+            <span class="platform-icon ig" style="width:14px;height:14px;font-size:7px;">IG</span>
+          {% elif p.platform == 'whatsapp' %}
+            <span class="platform-icon wa" style="width:14px;height:14px;font-size:8px;">W</span>
+          {% elif p.platform == 'threads' %}
+            <span class="platform-icon th" style="width:14px;height:14px;font-size:8px;">@</span>
+          {% else %}
+            <span class="platform-icon fb" style="width:14px;height:14px;font-size:8px;">f</span>
+          {% endif %}
+        </div>
+        <div class="post-message">{{ p.message }}</div>
+        <div class="post-meta">
+          <span>{{ p.account_name }}</span>
+          <span>·</span>
+          <span data-tip="{{ p.published_at }}">{{ p.published_at | time_ago }}</span>
+        </div>
+        <div class="post-actions">
+          {% if p.permalink_url %}
+            <a class="btn btn-ghost btn-sm" href="{{ p.permalink_url }}" target="_blank" rel="noopener">
+              view
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" style="width:11px;height:11px;"><path d="M7 17L17 7M7 7h10v10" stroke-linecap="round" stroke-linejoin="round"/></svg>
+            </a>
+          {% endif %}
+        </div>
+      </div>
+    {% endfor %}
+  </div>
+  {% else %}
+  <div class="post-list">
+    <div class="empty">
+      <div class="empty-icon">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M22 2L11 13M22 2l-7 20-4-9-9-4 20-7z" stroke-linecap="round" stroke-linejoin="round"/></svg>
+      </div>
+      <div class="empty-title">No posts published yet</div>
+      <div class="empty-body">Approve posts from the Inbox and they'll show up here.</div>
+    </div>
+  </div>
+  {% endif %}
+
+{% endblock %}

--- a/dashboard/templates/settings.html
+++ b/dashboard/templates/settings.html
@@ -1,142 +1,83 @@
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Social Auto Engine — Settings</title>
-  <link rel="icon" type="image/svg+xml" href="/static/favicon.svg">
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="/static/styles.css">
-  <script src="https://unpkg.com/htmx.org@2.0.4" crossorigin="anonymous"></script>
-</head>
-<body>
+{% extends "_base.html" %}
+{% block title %}Social Auto Engine — Settings{% endblock %}
+{% block breadcrumb %}Settings{% endblock %}
 
-<div class="app">
+{% block content %}
 
-  <aside class="sidebar">
-    <div class="sidebar-brand">
-      <div class="brand-mark">SAE</div>
-      <div class="brand-text">Social Auto Engine</div>
+  <div class="page-header">
+    <div>
+      <h1 class="page-title">Settings</h1>
+      <p class="page-description">Connected accounts and environment. Credentials live in <code class="kbd">.env</code>.</p>
     </div>
+  </div>
 
-    <nav class="sidebar-section">
-      <div class="sidebar-section-label">Workspace</div>
-      <a class="nav-item" href="/">
-        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M22 12h-6l-2 3h-4l-2-3H2" stroke-linecap="round" stroke-linejoin="round"/><path d="M5.45 5.11L2 12v6a2 2 0 002 2h16a2 2 0 002-2v-6l-3.45-6.89A2 2 0 0016.76 4H7.24a2 2 0 00-1.79 1.11z" stroke-linecap="round" stroke-linejoin="round"/></svg>
-        Inbox
-        {% if stats.get('pending', 0) %}
-          <span class="badge">{{ stats.get('pending', 0) }}</span>
-        {% endif %}
-      </a>
-    </nav>
-
-    <nav class="sidebar-section sidebar-footer">
-      <a class="nav-item active" href="/settings">
-        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><circle cx="12" cy="12" r="3" stroke-linecap="round" stroke-linejoin="round"/><path d="M19.4 15a1.65 1.65 0 00.33 1.82l.06.06a2 2 0 01-2.83 2.83l-.06-.06a1.65 1.65 0 00-1.82-.33 1.65 1.65 0 00-1 1.51V21a2 2 0 01-4 0v-.09A1.65 1.65 0 009 19.4a1.65 1.65 0 00-1.82.33l-.06.06a2 2 0 01-2.83-2.83l.06-.06a1.65 1.65 0 00.33-1.82 1.65 1.65 0 00-1.51-1H3a2 2 0 010-4h.09A1.65 1.65 0 004.6 9a1.65 1.65 0 00-.33-1.82l-.06-.06a2 2 0 012.83-2.83l.06.06a1.65 1.65 0 001.82.33H9a1.65 1.65 0 001-1.51V3a2 2 0 014 0v.09a1.65 1.65 0 001 1.51 1.65 1.65 0 001.82-.33l.06-.06a2 2 0 012.83 2.83l-.06.06a1.65 1.65 0 00-.33 1.82V9a1.65 1.65 0 001.51 1H21a2 2 0 010 4h-.09a1.65 1.65 0 00-1.51 1z" stroke-linecap="round" stroke-linejoin="round"/></svg>
-        Settings
-      </a>
-    </nav>
-  </aside>
-
-  <main class="main">
-
-    <header class="topbar">
-      <div class="breadcrumb">
-        <a class="breadcrumb-link" href="/">Workspace</a>
-        <span class="breadcrumb-sep">/</span>
-        <span class="breadcrumb-current">Settings</span>
-      </div>
-    </header>
-
-    <div class="page">
-
-      <div class="page-header">
-        <div>
-          <h1 class="page-title">Settings</h1>
-          <p class="page-description">Connected accounts and environment. All credentials live in <code class="kbd">.env</code>.</p>
-        </div>
-      </div>
-
-      <!-- Accounts -->
-      <section class="section">
-        <div class="section-header">
-          <h2 class="section-title">Connected accounts</h2>
-        </div>
-        <div class="post-list">
-          {% for a in accounts %}
-            <div class="post-row" id="acc-{{ a.platform }}">
-              <div class="post-status">
-                <span class="platform-icon {{ a.icon_class }}" style="width:18px;height:18px;font-size:9px;">{{ a.icon_label }}</span>
-                <span class="post-status-label">{{ a.platform_label }}</span>
-              </div>
-              <div class="acc-name">
-                <div class="acc-name-primary">{{ a.name }}</div>
-                {% if a.details %}<div class="acc-name-secondary">{{ a.details }}</div>{% endif %}
-              </div>
-              <div class="post-meta">
-                {% if a.connected %}
-                  <span class="conn-status ok">✓ Connected</span>
-                {% else %}
-                  <span class="conn-status off">○ Not connected</span>
-                {% endif %}
-                <span>·</span>
-                <span>{{ a.id }}</span>
-              </div>
-              <div class="post-actions">
-                {% if a.connected %}
-                  <button class="btn btn-ghost btn-sm"
-                          hx-post="/settings/test/{{ a.platform }}"
-                          hx-target="#acc-{{ a.platform }} .conn-status"
-                          hx-swap="outerHTML">
-                    Test
-                  </button>
-                {% endif %}
-              </div>
-            </div>
-          {% endfor %}
-        </div>
-      </section>
-
-      <!-- Env vars -->
-      <section class="section">
-        <div class="section-header">
-          <h2 class="section-title">Environment</h2>
-        </div>
-        <div class="post-list">
-          {% for k, v in env.items() %}
-            <div class="post-row">
-              <div class="post-status">
-                <span class="post-status-label">{{ k }}</span>
-              </div>
-              <div class="env-value">
-                {% if v == 'set' %}
-                  <span class="conn-status ok">✓ set</span>
-                {% elif v == 'missing' %}
-                  <span class="conn-status off">missing</span>
-                {% else %}
-                  <code>{{ v }}</code>
-                {% endif %}
-              </div>
-              <div></div>
-              <div></div>
-            </div>
-          {% endfor %}
-        </div>
-        <p class="env-help">
-          Edit <code class="kbd">.env</code> in the project root and restart the dashboard to apply changes.
-          <a href="https://github.com/Freespirits/social-auto-engine/blob/main/.env.example" target="_blank" rel="noopener">See example</a>.
-        </p>
-      </section>
-
+  <!-- Accounts -->
+  <section class="section">
+    <div class="section-header">
+      <h2 class="section-title">Connected accounts</h2>
     </div>
+    <div class="post-list">
+      {% for a in accounts %}
+        <div class="post-row" id="acc-{{ a.platform }}">
+          <div class="post-status">
+            <span class="platform-icon {{ a.icon_class }}" style="width:18px;height:18px;font-size:9px;">{{ a.icon_label }}</span>
+            <span class="post-status-label">{{ a.platform_label }}</span>
+          </div>
+          <div class="acc-name">
+            <div class="acc-name-primary">{{ a.name }}</div>
+            {% if a.details %}<div class="acc-name-secondary">{{ a.details }}</div>{% endif %}
+          </div>
+          <div class="post-meta">
+            {% if a.connected %}
+              <span class="conn-status ok">Connected</span>
+            {% else %}
+              <span class="conn-status off">Not connected</span>
+            {% endif %}
+          </div>
+          <div class="post-actions">
+            {% if a.connected %}
+              <button class="btn btn-ghost btn-sm"
+                      hx-post="/settings/test/{{ a.platform }}"
+                      hx-target="#acc-{{ a.platform }} .conn-status"
+                      hx-swap="outerHTML">
+                Test
+              </button>
+            {% endif %}
+          </div>
+        </div>
+      {% endfor %}
+    </div>
+  </section>
 
-  </main>
+  <!-- Env vars -->
+  <section class="section">
+    <div class="section-header">
+      <h2 class="section-title">Environment</h2>
+    </div>
+    <div class="post-list">
+      {% for k, v in env.items() %}
+        <div class="post-row">
+          <div class="post-status">
+            <span class="post-status-label">{{ k }}</span>
+          </div>
+          <div class="env-value">
+            {% if v == 'set' %}
+              <span class="conn-status ok">set</span>
+            {% elif v == 'missing' %}
+              <span class="conn-status off">missing</span>
+            {% else %}
+              <code>{{ v }}</code>
+            {% endif %}
+          </div>
+          <div></div>
+          <div></div>
+        </div>
+      {% endfor %}
+    </div>
+    <p class="env-help">
+      Edit <code class="kbd">.env</code> and restart to apply.
+      <a href="https://github.com/Freespirits/social-auto-engine/blob/main/.env.example" target="_blank" rel="noopener">See example</a>.
+    </p>
+  </section>
 
-</div>
-
-{% include "_toast.html" %}
-
-</body>
-</html>
+{% endblock %}

--- a/dashboard/templates/settings.html
+++ b/dashboard/templates/settings.html
@@ -42,6 +42,19 @@
                       hx-swap="outerHTML">
                 Test
               </button>
+              {% if a.platform in ['linkedin', 'tiktok', 'youtube'] %}
+                <form method="post" action="/oauth/{{ a.platform }}/disconnect" style="margin:0;display:inline;">
+                  <button class="btn btn-ghost btn-sm"
+                          type="submit"
+                          data-tip="Clear stored token">Disconnect</button>
+                </form>
+              {% endif %}
+            {% else %}
+              {% if a.platform in ['linkedin', 'tiktok', 'youtube'] %}
+                <a class="btn btn-primary btn-sm" href="/oauth/{{ a.platform }}/start">Connect</a>
+              {% else %}
+                <span class="acc-name-secondary" style="font-size:11px;">Set credentials in <code class="kbd">.env</code></span>
+              {% endif %}
             {% endif %}
           </div>
         </div>

--- a/docs/audit-2026-05-06.md
+++ b/docs/audit-2026-05-06.md
@@ -1,0 +1,138 @@
+# Code-and-doc audit — 2026-05-06
+
+Scope: a quality-sweep-style review of `Freespirits/social-auto-engine` to find the kind of issues that would have flagged us in the awesome-mcp-servers cleanup pass on 2026-05-04. Findings only, no silent fixes.
+
+## TL;DR
+
+The project is materially in better shape than the cleanup-sweep-removed projects on average. The biggest single risk is **README overclaim**: the hero copy promises six platforms but only four-and-a-half are actually shippable today. Fix the README, the rest is paper cuts.
+
+---
+
+## Findings, ranked by impact
+
+### 1. README overclaims platform support (HIGH)
+
+**File:** `README.md`
+
+The hero alt text says "five platforms" and the hero paragraph says "Facebook, Instagram, WhatsApp, LinkedIn, X, and TikTok" (six platforms). Reality, after the fan-out work landed:
+
+| Platform   | Adapter | Broadcast composer | Status            |
+|------------|---------|--------------------|-------------------|
+| Facebook   | yes     | yes                | shippable         |
+| Instagram  | yes     | yes                | shippable         |
+| WhatsApp   | yes     | direct only (1:1)  | shippable         |
+| Threads    | yes     | yes                | shippable         |
+| LinkedIn   | yes     | yes                | needs LINKEDIN_*  |
+| TikTok     | no      | placeholder (soon) | not implemented   |
+| X / Twitter| no      | placeholder (soon) | not implemented   |
+| YouTube    | no      | placeholder (soon) | not implemented   |
+
+A quality reviewer reading the README and then `git grep tiktok` finds nothing meaningful. That gap is exactly the kind of thing that prompts a "looks half-finished" call.
+
+**Recommendation:** revise the hero to read "Publish to Facebook, Instagram, Threads, WhatsApp, and LinkedIn from a single dashboard. TikTok, YouTube, and X are on the roadmap." Honest and still impressive.
+
+### 2. Hard-coded "Hack-Tech" account label leaks into multiple places (MEDIUM)
+
+**Files:** `dashboard/app.py`, `dashboard/db.py` (default), composer copy
+
+`account_name="Hack-Tech"` is wired in as the Facebook default account label. It surfaces in the inbox UI (`p.account_name → recipient`), in fallback page info when the FB API fails, and as the literal default in `db.create_post`.
+
+This is fine for solo Ori, awkward for anyone else who clones the repo. Two reasonable fixes:
+
+- Default to `os.getenv("FACEBOOK_PAGE_NAME") or page_info.get("name") or "Facebook"`.
+- Or surface it as a settings field once and treat the literal "Hack-Tech" as a per-deployment value, not a code constant.
+
+### 3. `_safe_page_info` masks a real connection failure with a fake success (MEDIUM)
+
+**File:** `dashboard/app.py:628`
+
+When the Facebook Graph API call errors, the fallback returns a hard-coded dict `{"id": page_id, "name": "Hack-Tech", "category": "Education website"}`. The connection-status code then reads `bool(info.get("id"))` and concludes the page is connected because the fallback id is the literal string `"?"` from `os.getenv("FACEBOOK_PAGE_ID", "?")`, which is truthy.
+
+Net effect: the dashboard will show Facebook as "connected" even when the token is missing or expired. That is a silent-failure pattern.
+
+**Recommendation:** the fallback should return `{"connected": False, "error": str(exc)}` like the other adapters do, and the connection-status helper should check `bool(info.get("connected"))` consistently.
+
+### 4. Sidebar accounts and settings page disagree on which platforms exist (LOW)
+
+**Files:** `dashboard/app.py:_sidebar_groups` and `dashboard/app.py:settings`
+
+After the fan-out work, the sidebar lists Meta / LinkedIn / TikTok / YouTube / X. The settings page lists Facebook / Instagram / WhatsApp / Threads / LinkedIn / X / TikTok (and inside settings, the "coming" status mentions issue #5 and `integrations.md`).
+
+These two surfaces should be generated from the same source of truth (a single `PLATFORMS` list with `{key, label, company, has_adapter}` per entry). Right now they drift trivially every time a platform is added.
+
+**Recommendation:** extract to a module-level constant, generate both views from it.
+
+### 5. Old commented and stale TODOs (LOW)
+
+`grep -rn "TODO\|FIXME\|XXX" --include='*.py'` should be clean before a re-application. Spot-check:
+
+- `manager.py` and the adapter modules contain no obvious `TODO` markers, good.
+- `dashboard/app.py` has `# TODO`-shaped notes only as section dividers, also good.
+
+The codebase passes a casual TODO scan. No action needed.
+
+### 6. Missing test suite (LOW for the sweep, HIGH for credibility)
+
+There is no `tests/` directory. Maintainers of a list see "0 tests" and infer "early alpha, will break" — which is honest, but easy to fix.
+
+A minimum-viable test set:
+
+- `tests/test_db.py` — `init_db`, `create_post`, `create_broadcast`, `list_pending_grouped`. SQLite tests are pure and fast.
+- `tests/test_compose.py` — POST /compose with a list of platforms, assert N rows created with the same group_id. Use FastAPI's `TestClient` (already used in this audit's smoke tests).
+- `tests/test_adapters_smoke.py` — instantiate each adapter without calling out, assert no import errors. Cheap, catches integration-layer breakage.
+
+That alone takes the project from "no tests" to "real tests pass on every CI run." Add a GitHub Actions workflow at `.github/workflows/test.yml` to round it out.
+
+### 7. `dashboard/app.py` is starting to outgrow its single-file home (LOW)
+
+Currently 800+ lines after the fan-out work. Routes, sidebar context, publish dispatch, settings, scheduler endpoints, and auth routes all live in one file. Not a problem yet, will be soon.
+
+**Recommendation, when convenient:** split into `dashboard/routes_inbox.py`, `dashboard/routes_settings.py`, `dashboard/routes_auth.py`, `dashboard/routes_scheduler.py`. Keep `app.py` as the wiring file. Not urgent.
+
+### 8. Integrations markdown lists things that the actual project doesn't ship (LOW)
+
+`docs/integrations.md` mentions 24 OSS projects. Confirm each is still maintained and the link still resolves. Quick `curl -I` over the URLs catches dead links.
+
+### 9. No CHANGELOG (LOW)
+
+Awesome-list maintainers sometimes look at `CHANGELOG.md` to gauge activity. We have a master plan that has a status section now (good), but a separate `CHANGELOG.md` that records each merged PR with a one-liner is a tiny amount of work and a meaningful signal.
+
+### 10. Voice consistency in user-facing copy (LOW)
+
+Spot-checked `dashboard/templates/index.html` — copy is clean, British English, no em dashes, no semicolons. Matches the rules in `CLAUDE.md`. No action.
+
+---
+
+## Things that are GOOD and should stay good
+
+- **Approval queue spine.** Every code path goes through `db.create_post → status='pending' → /approve → _publish_post`. The fan-out work preserves this. This is the project's safety story and it is intact.
+- **Adapter shape consistency.** All adapters follow the `LinkedInAPI._request → public method returning {success, id}` shape. Easy to extend.
+- **No silent-automation backdoors.** Searched for `subprocess`, `playwright`, `selenium`, `puppeteer`, scrapers — nothing. Good.
+- **Per-platform lightweight migration pattern.** `db.init_db` adds columns with `ALTER TABLE` checks. Cleanly handles old database files.
+- **Self-hostedness is real.** All persistence sits under `~/.social-auto-engine/`. No phone-home.
+- **Recent active commits.** Master plan, CLAUDE.md, About-the-maintainer all landed in the last week. Activity signal is strong.
+
+---
+
+## What I'd do before re-applying to a list
+
+In rough order:
+
+1. Fix the README hero overclaim (15 minutes).
+2. Fix `_safe_page_info` silent-failure pattern (30 minutes).
+3. Add a minimal `tests/` directory (90 minutes).
+4. Replace hard-coded "Hack-Tech" with config (30 minutes).
+5. Extract a single `PLATFORMS` source of truth (45 minutes).
+6. Add `CHANGELOG.md` and back-fill the last two weeks of merged PRs (30 minutes).
+
+Total: ~4 hours of focused work, no big architectural changes. Then the project genuinely matches the description it gives in any awesome-list entry.
+
+The existing fan-out feature (this iteration) plus a clean README pass is the strongest re-application story available. Wait until LinkedIn keys are confirmed working end to end on a real account before submitting.
+
+---
+
+## Out of scope for this audit
+
+- Performance / scaling. No issues at the current scale, no point optimising prematurely.
+- Security pen-test. The auth layer is a single password cookie; that is documented honestly. A real security audit waits until there is real exposure.
+- I18n. Promoted to active priority elsewhere, not part of "what flagged us."

--- a/docs/platform-tiers.md
+++ b/docs/platform-tiers.md
@@ -1,0 +1,110 @@
+# Platform tiers — what each social platform's API actually grants
+
+> Status: living reference. Last verified 2026-05-06. Tier policies change.
+> Always cross-check developer.x.com / developers.tiktok.com / etc before
+> committing capacity to a paid tier.
+
+This is a single source of truth for the dashboard's UI gating, the
+adapter capability checks, and the docs that tell users what to expect.
+When a platform changes its rules, update this file first, then the
+adapter code that reads from it.
+
+## Why we care
+
+Platform tiers shape three UX decisions inside social-auto-engine:
+
+1. **Which features the dashboard offers a connected account.** No "show analytics" button when the user is on a tier without read access.
+2. **How much volume the scheduler will queue.** If a tier permits 50 posts a month, the queue must refuse the 51st with a clear message.
+3. **What the connection card shows.** A small badge next to the account name (Free / Basic / Pro / Member / MDP) so the user knows their cap at a glance.
+
+The adapters *do not* try to upgrade tiers automatically. The rule is the same as the rest of the project: nothing silent. Tier upgrades happen in the platform's developer portal, with the user's eyes open and their money explicit.
+
+## X / Twitter
+
+| Tier | Cost | Writes/mo | Reads | OAuth-as-user | Suitable for |
+|---|---|---|---|---|---|
+| Free | $0 | ~1,500 (changes often) | essentially none | yes | Tinkering only. Don't ship behind it. |
+| Basic | ~$200/mo (was $100, raised late 2024) | ~50,000 | limited | yes | Single creator or tiny agency posting their own accounts. |
+| Pro | $5,000/mo | ~1,000,000 | full | yes | A real third-party SaaS scheduler with multiple paying users. |
+| Enterprise | custom (six figures+) | bespoke | bespoke | yes | Out of scope for this project. |
+
+**Rule we apply:** social-auto-engine does not ship X support out of the box. Users supply their own X developer credentials in `.env`. Each user pays their own X bill.
+
+**Common confusion:** **X Premium / Premium+** ($8/$16 a month) is a *consumer* subscription that gets the user a blue check, longer posts, and Grok in the browser. It does *not* unlock the X developer API. The two systems are billed separately and managed in completely different portals.
+
+**Grok API** (api.x.ai) is yet another product, an LLM API similar to OpenAI's. It does not let you post on behalf of a user. It is a candidate AI-compose backend, not an X-publishing backend.
+
+## TikTok
+
+| Tier | Cost | Capability | What it requires | Suitable for |
+|---|---|---|---|---|
+| Sandbox | $0 | Test the API against sandbox-listed test users | Dev app registration | Building and testing locally. |
+| Inbox upload | $0 | `video.upload` scope, video lands in user's drafts. User taps Publish in TikTok app to finalise. | Sandbox graduation, Terms + Privacy URLs, app description | Single creator or scheduling tool that is happy with a manual final step. **This is what social-auto-engine ships today.** |
+| Direct post | $0 | `video.publish` scope, video publishes immediately | Full TikTok app review (security questionnaire, demo videos, business verification) | A SaaS that has earned the right by going through review. |
+
+**Rule we apply:** social-auto-engine implements only the inbox-upload tier. The "user finalises in the TikTok app" step is presented as a feature in the UI ("you stay in control of what TikTok sees you doing"), not a limitation. When a user has direct-post approved, we add it as an opt-in toggle on the connection card.
+
+**Rate limits to know:**
+
+- Inbox-upload init: 6 requests per minute per user access token
+- Maximum 5 pending drafts within any 24-hour rolling window
+- For PULL_FROM_URL: domain must be pre-verified in the TikTok dev portal
+
+## LinkedIn
+
+| Tier | Cost | Capability | What it requires | Suitable for |
+|---|---|---|---|---|
+| Member (default) | $0 | `w_member_social` scope, post as the authenticated user | Standard developer app, no manual review | Single creator or small tool that posts the user's own content. **This is what social-auto-engine ships today.** |
+| Marketing Developer Platform | $0 fee, but gated review | Post as a Company Page on behalf of an organisation, plus analytics | LinkedIn manual review, takes weeks-to-months, frequently rejected for tools without existing paying users | Agency tools managing multiple LinkedIn pages. |
+
+**Rule we apply:** member-tier first. Mark MDP as a Phase 2 unlock. Do not block the launch on it.
+
+**Rate limits:** 100 posts per day per member.
+
+## YouTube
+
+| Tier | Cost | Capability | What it requires | Suitable for |
+|---|---|---|---|---|
+| Default project | $0 | 10,000 quota units / day, ~100 video uploads / day per project | Google Cloud project, OAuth setup | Personal use, small creator. |
+| Audited / increased quota | $0 fee, but gated request | Higher daily quota for Shorts and analytics | Quota-increase request to Google with usage justification | Anyone hitting the cap. |
+
+**Rule we apply:** default project quota covers any reasonable single-user case. The quota-increase request is a Phase 2 task once we have signal that someone is hitting the cap.
+
+**Quota costs:**
+
+- `videos.insert` (upload): 100 units. So 100 uploads / day on the default 10,000-unit allowance.
+- `channels.list`: 1 unit.
+- `videos.delete`: 50 units.
+
+## Meta (Facebook, Instagram, WhatsApp, Threads)
+
+| Tier | Cost | Capability | What it requires | Suitable for |
+|---|---|---|---|---|
+| Development mode | $0 | Test with users explicitly added to the app | App registration | Building locally. |
+| Live mode (basic permissions) | $0 | `pages_read_engagement`, `pages_manage_posts`, `instagram_content_publish`, `whatsapp_business_messaging`, `threads_basic`, `threads_content_publish` | App Review for each permission, manual approval | Production use against any user. |
+| Live mode (advanced permissions) | $0 | `pages_messaging`, more granular insights, Marketing API | Heavier App Review | Larger production tools. |
+
+**Rule we apply:** social-auto-engine targets the basic-permissions set. The MCP server's full 37-tool suite uses exactly the standard Graph permissions, no advanced ones. App Review is the bottleneck, not the cost.
+
+## How adapters should consume this matrix
+
+Future shape (when the X adapter or the LinkedIn MDP path is built):
+
+```python
+# capabilities/x.py
+TIERS = {
+    "free":  {"post_text": True, "post_media": False, "monthly_writes": 1500,    "read": False},
+    "basic": {"post_text": True, "post_media": True,  "monthly_writes": 50000,   "read": True},
+    "pro":   {"post_text": True, "post_media": True,  "monthly_writes": 1000000, "read": True},
+}
+```
+
+Each adapter reads its own tier from `.env` (`X_TIER=basic`, `LINKEDIN_TIER=member`, `TIKTOK_TIER=inbox`, etc), defaults to the most-restricted tier. Each public method does an early `if not TIERS[self.tier]["post_media"]: return {"success": False, "error": "..."}`.
+
+The dashboard's compose UI reads the same matrix to disable / enable per-platform features and to surface upgrade prompts.
+
+## When this file becomes wrong
+
+- A platform changes its tier names, prices, or limits. Update the table above first, the adapter code second, the README third. Always in that order.
+- Add the date of the change in the corresponding table row, e.g. *"Basic raised from \$100 to \$200/mo (effective ~late 2024)"*.
+- If a platform reorganises its developer programme (X has done this twice in two years), keep the old table for historical reference under a "## Old tiers" heading rather than rewriting from scratch.

--- a/docs/specs/2026-05-06-company-grouped-ui-and-multi-platform-compose-design.md
+++ b/docs/specs/2026-05-06-company-grouped-ui-and-multi-platform-compose-design.md
@@ -1,0 +1,291 @@
+# Company-grouped UI and multi-platform fan-out compose
+
+**Status:** Design draft, 2026-05-06.
+**Author:** Generated with Claude Code, reviewed by Ori Siracki.
+**Predecessors:** [`2026-05-02-multi-channel-platform-master-plan.md`](./2026-05-02-multi-channel-platform-master-plan.md), [`2026-05-02-approval-queue-and-dashboard-mvp-design.md`](./2026-05-02-approval-queue-and-dashboard-mvp-design.md).
+
+## Goal
+
+Make social-auto-engine a true multi-platform tool, both in capability and in UX:
+
+1. Compose a single creative once and publish it to several platforms in one action.
+2. Organise the dashboard so the user thinks in **company groups** (Meta, LinkedIn, TikTok, YouTube, X) rather than a flat list of platforms.
+3. Keep the approval-queue spine intact. Every fan-out post is still reviewed before it goes live.
+
+This design is the bridge between the four-Meta-only adapters of today and the cross-platform scheduler the project is positioned as on awesome-mcp-servers and similar listings.
+
+## Non-goals for this iteration
+
+- No browser automation, ever. Every platform must be reached through its official API. Three reasons stacked:
+  - Violates ToS of every supported platform; ban risk lands on the user's account.
+  - Contradicts the "no silent automation" spine that is the project's safety story.
+  - Specifically toxic for the maintainer who is currently freelancing for Meta.
+- No analytics dashboard in this iteration. The fan-out result is success / failure per platform, nothing fancier.
+- No team / multi-user permissions. Single-tenant remains the default.
+- No drag-and-drop calendar editing. Existing scheduler stays the same.
+
+## Prior art reviewed
+
+- **[Postiz](https://github.com/gitroomhq/postiz-app)** (AGPL-3.0, NextJS / NestJS / Prisma / Temporal). Pattern study only — its AGPL licence prevents code reuse without re-licensing this project.
+- **[Mixpost](https://github.com/inovector/MixPost)** (MIT, Laravel / Vue). Confirms the single-post-with-variants model ("Post Versions and Conditions"). MIT compatible if anything turns out to be worth copying line-for-line.
+- **[facebook-mcp-server by Hagai Hen](https://github.com/HagaiHen/facebook-mcp-server)** — the project's own foundation, single platform per call.
+- **[charlie947/social-media-skills](https://github.com/charlie947/social-media-skills)** — informs voice and content patterns, no fan-out concept.
+
+The convergent shape across mature schedulers is: **one creative, N platform-specific outputs, per-platform overrides where useful, partial-failure tolerated.**
+
+## Data model
+
+### Current (single-platform per row)
+
+```
+post(id, platform, account_name, message, image_url, recipient, template_name,
+     status, platform_post_id, error_message,
+     created_at, decided_at, published_at, scheduled_for, permalink_url)
+```
+
+Each row is one post on one platform.
+
+### New (group_id ties N platform rows together)
+
+Add a single column:
+
+```sql
+ALTER TABLE post ADD COLUMN group_id TEXT;
+CREATE INDEX IF NOT EXISTS idx_post_group ON post(group_id);
+```
+
+Semantics:
+
+- A post created from the **broadcast composer** gets a freshly generated UUID4 `group_id`. Every platform target produces its own row, all sharing that `group_id`.
+- A post created from the **single-platform composer** (e.g. WhatsApp 1:1 messaging, which is not a broadcast) leaves `group_id` NULL.
+- A post created from the **MCP server or external API** also leaves `group_id` NULL by default. External callers can supply one if they want to bundle.
+
+Each row keeps independent `status`, `error_message`, and `published_at`. A "group" is fully published when every row in the group has `status='published'`. A group with at least one `status='failed'` row is partially published — the UI must distinguish this.
+
+### Why this shape
+
+- **Minimum viable migration.** One column, no table split, additive change, safe to run on existing databases.
+- **Independent per-platform status is correct semantics.** Twitter could fail at the rate limit while LinkedIn succeeds; the user must see the partial outcome accurately.
+- **Existing single-platform code paths keep working unchanged.** `_publish_post` already dispatches by `post.platform`; nothing in the publish path needs to change.
+- **Approve-all-in-group becomes a thin SQL filter** rather than a new code path.
+
+## API surface
+
+### Existing endpoints (unchanged)
+
+- `GET /` — inbox
+- `GET /calendar`
+- `GET /published`
+- `GET /settings`
+- `POST /approve/{post_id}`
+- `POST /reject/{post_id}`
+- `POST /schedule/{post_id}`
+- `POST /unschedule/{post_id}`
+
+### Modified
+
+- `POST /compose` — accepts a `platforms` form list (one or more) plus existing fields. Creates N rows under one `group_id` and returns the refreshed view.
+  - Backwards compatibility: a single `platform` field still works (degrades to a one-row group), so any external caller using the current shape is unaffected.
+
+### New
+
+- `POST /approve-group/{group_id}` — approve and publish every pending row sharing that group_id.
+- `POST /reject-group/{group_id}` — reject every pending row in the group.
+
+## Composer UX
+
+The composer has two modes, selected by tab at the top:
+
+1. **Broadcast** — fan-out across selected social platforms. Default mode.
+2. **Direct message** — WhatsApp 1:1 messaging. Same form as today, just one platform.
+
+Reasoning for the split: WhatsApp Business is fundamentally 1:1, requires a recipient phone number, and uses templated messages. Forcing it into a multi-checkbox broadcast UI confuses both shapes. A tab keeps the broadcast experience clean and acknowledges WA's different model honestly.
+
+### Broadcast layout
+
+```
+┌────────────────────────────────────────────────────────────────┐
+│ New broadcast post                                              │
+├────────────────────────────────────────────────────────────────┤
+│ Publish to:                                                     │
+│  ┌─ Meta ─────────────────────────────────────────────────────┐ │
+│  │ [✓] Facebook    [✓] Instagram    [✓] Threads               │ │
+│  └────────────────────────────────────────────────────────────┘ │
+│  ┌─ LinkedIn ─────────────────────────────────────────────────┐ │
+│  │ [✓] LinkedIn (member)                                      │ │
+│  └────────────────────────────────────────────────────────────┘ │
+│  ┌─ TikTok ───────────────────────────────────────────────────┐ │
+│  │ [ ] TikTok (inbox upload)         (connect first)          │ │
+│  └────────────────────────────────────────────────────────────┘ │
+│  ...                                                             │
+├────────────────────────────────────────────────────────────────┤
+│ Message                                                         │
+│ ┌────────────────────────────────────────────────────────────┐ │
+│ │                                                            │ │
+│ └────────────────────────────────────────────────────────────┘ │
+│ Image URL (optional, required for Instagram)                    │
+├────────────────────────────────────────────────────────────────┤
+│ Per-platform overrides ▸ (collapsed by default)                 │
+│   - Twitter / X version (280 char limit warning)                │
+│   - LinkedIn version (3000 char limit)                          │
+│   - Threads version (500 char limit)                            │
+├────────────────────────────────────────────────────────────────┤
+│ Will create 4 pending posts        [Cancel]  [Add to queue]     │
+└────────────────────────────────────────────────────────────────┘
+```
+
+Per-platform character limits (informational, not enforced server-side in this iteration):
+
+| Platform   | Limit  |
+|------------|--------|
+| Facebook   | 63,206 |
+| Instagram  | 2,200  |
+| Threads    | 500    |
+| LinkedIn   | 3,000  |
+| Twitter/X  | 280    |
+| TikTok cap | 2,200  |
+| YouTube    | 5,000  |
+
+The composer shows a warning when the master message exceeds a selected platform's limit and offers a one-click "use override" to truncate or rewrite for that platform. The user makes the final call.
+
+### Disabled state for unconnected platforms
+
+Each checkbox is disabled when the platform is not connected, with hover text "Not connected — go to Settings". The Settings page already exists and surfaces all platforms regardless of connection state, so the user has a clear path to fix.
+
+## Sidebar UX
+
+Replace the flat `Accounts` list with company-grouped collapsible sections:
+
+```
+┌──────────────────────┐
+│ Workspace            │
+│  • Inbox    [3]      │
+│  • Calendar [1]      │
+│  • Published         │
+├──────────────────────┤
+│ Meta            ▾    │
+│  ▪ Hack-Tech (FB)    │
+│  ▪ @hack_tech (IG)   │
+│  ▪ @threads_handle   │
+│  ▪ +972… (WA)        │
+├──────────────────────┤
+│ LinkedIn        ▾    │
+│  ▪ Ori Siracki       │
+├──────────────────────┤
+│ TikTok          ▾    │
+│  ○ Not connected     │
+├──────────────────────┤
+│ YouTube         ▾    │
+│  ○ Not connected     │
+├──────────────────────┤
+│ X               ▾    │
+│  ○ Not connected     │
+├──────────────────────┤
+│ Settings             │
+│ Sign out             │
+└──────────────────────┘
+```
+
+- Each company section is collapsible (purely cosmetic, state stored in `localStorage`).
+- The connection dot stays the same primitive.
+- Order is fixed: Meta first (it has the most adapters today), then LinkedIn, TikTok, YouTube, X. Order can become user-configurable later.
+
+## Approval queue UX
+
+For grouped posts, the approval queue collapses N rows into a single card:
+
+```
+┌────────────────────────────────────────────────────────────────┐
+│ ● Pending broadcast — 4 platforms                               │
+│                                                                  │
+│ "Big news: we just shipped multi-platform fan-out…"             │
+│                                                                  │
+│  [f]  Facebook        ✓ ready                                   │
+│  [IG] Instagram       ✓ ready                                   │
+│  [@]  Threads         ✓ ready                                   │
+│  [in] LinkedIn        ✓ ready                                   │
+│                                                                  │
+│  Created 3m ago                                                 │
+│                                                                  │
+│  [Publish all]   [Reject all]   [Edit per platform ▸]           │
+└────────────────────────────────────────────────────────────────┘
+```
+
+After "Publish all" is pressed, the card stays visible and updates each row's status as the dispatches complete:
+
+```
+│  [f]  Facebook        ✓ Live (view ↗)
+│  [IG] Instagram       ✓ Live (view ↗)
+│  [@]  Threads         ✗ Failed: 'OAuthException: token expired'
+│  [in] LinkedIn        ⏳ Publishing...
+```
+
+Single-platform posts (group_id NULL) render as today.
+
+## Adapter dispatch and partial failure
+
+`_publish_post(post)` is unchanged at the row level. The new `/approve-group/{group_id}` endpoint:
+
+```python
+def approve_group(group_id):
+    rows = db.list_group(group_id, status="pending")
+    results = []
+    for post in rows:
+        _publish_post(post)
+        refreshed = db.get_post(post["id"])
+        results.append((post["platform"], refreshed["status"]))
+    return _refresh_all(request, toast=_toast_for_group_result(results))
+```
+
+Sequential dispatch is fine for v1. Each adapter call is bounded by a 30 second timeout (already enforced in `LinkedInAPI._request`, similar elsewhere). Worst case is `N × 30s`, which is acceptable for the small number of platforms a single user fans out to.
+
+A future iteration can move dispatch to a background task queue (APScheduler is already present, would just need a transient job) if the response time becomes a UX problem.
+
+### Toast for group result
+
+| All published | "Published to Facebook, Instagram, Threads, LinkedIn" |
+| Some failed   | "Published 3 of 4: failed on Threads (token expired)" |
+| All failed    | "All 4 publishes failed. See activity log."           |
+
+## Backwards compatibility
+
+- **Existing single-platform posts** keep working with `group_id` NULL. They render as today.
+- **External MCP callers** of `manager.post_to_facebook(...)` etc. are completely untouched. The fan-out feature is dashboard-only in this iteration.
+- **Existing `/compose` callers** sending a single `platform` field still work. Server treats it as a one-row group.
+- **DB migration** is purely additive. Existing `dashboard.db` files migrate cleanly via the same lightweight pattern already used in `db.init_db`.
+
+## Test plan
+
+Manual end-to-end tests on a fresh `~/.social-auto-engine/dashboard.db`:
+
+1. **Single-platform compose still works.** Compose a Facebook-only post via the legacy single-platform code path, verify it appears in pending, approve, verify it publishes.
+2. **Broadcast compose creates N rows.** Compose a broadcast to FB + IG + Threads + LinkedIn, verify four rows appear in pending with the same group_id, no platform_post_id yet.
+3. **Approve-all-in-group publishes all four.** Click "Publish all", verify all four rows transition to published or failed, group card updates per-row.
+4. **Partial failure surfaces correctly.** Manually expire a token in `.env`, repeat (3), verify the failing row shows the error and the group toast says "Published 3 of 4".
+5. **Reject-all-in-group rejects all four.** Verify all four rows transition to rejected.
+6. **Sidebar grouping renders.** Verify connected accounts appear under their company section, unconnected platforms show as "Not connected" placeholders.
+7. **WhatsApp tab still works.** WA flow lives in the "Direct message" tab and is unaffected by the broadcast changes.
+8. **Calendar view.** Confirm grouped posts render as one item or N items (whichever is more useful — pick by feel and document).
+
+Automated tests are out of scope for this iteration but the data shape (`group_id`) makes them easy to add later.
+
+## Migration / rollback
+
+- Forward migration is a single `ALTER TABLE` plus an index, run inside the existing `init_db` lightweight migrations.
+- Rollback: drop the column. SQLite does not support `DROP COLUMN` natively in older versions, so for safety the rollback path is "leave the column in place, ignore it" — the column has no NOT NULL constraint and no behavioural impact when unused.
+
+## Open questions for review
+
+1. **WhatsApp in broadcast?** Current proposal puts WA on its own tab because it is 1:1 not broadcast. Alternative: include WA in broadcast with a per-row recipient picker, but this gets messy fast. **Recommendation: keep separate, revisit when there is real demand.**
+2. **TikTok tier — inbox upload vs direct post?** Both, controlled by a per-account setting. Default to inbox upload because it is approvable without TikTok review; user opts in to direct post once their app is approved.
+3. **YouTube in this iteration?** The design covers it conceptually, the adapter is not implemented. **Recommendation: design includes the slot, implementation deferred to a follow-up PR. Don't ship a half-baked YouTube adapter.**
+4. **Per-platform image variants?** Today the same `image_url` is used for all platforms. Per-platform image overrides are a natural follow-up but not in this iteration. Use the master image, the user can edit per-platform later.
+
+## Out of scope, listed explicitly so they don't sneak in
+
+- Multi-image / carousel post composition (already exists as a skill, not in this UX work).
+- Rich-text editor with formatting per platform.
+- Post analytics dashboard.
+- Team collaboration / approval workflows beyond a single user.
+- Cross-platform comment moderation.
+- Native mobile app.

--- a/linkedin_api.py
+++ b/linkedin_api.py
@@ -1,0 +1,322 @@
+"""LinkedIn API adapter.
+
+LinkedIn uses its own REST API at api.linkedin.com (NOT the Meta Graph API).
+It uses 3-legged OAuth 2.0 for authentication.
+
+Publishing uses the UGC Post API (v2) or the newer Posts API:
+    POST https://api.linkedin.com/v2/ugcPosts
+
+The author URN is derived from the authenticated user's profile via
+    GET https://api.linkedin.com/v2/userinfo
+
+Permissions required: openid, profile, email, w_member_social
+
+Rate limits: 100 posts per day per member.
+"""
+from __future__ import annotations
+
+import os
+from typing import Any
+
+import requests
+
+
+LINKEDIN_API_BASE = "https://api.linkedin.com/v2"
+LINKEDIN_AUTH_URL = "https://www.linkedin.com/oauth/v2/authorization"
+LINKEDIN_TOKEN_URL = "https://www.linkedin.com/oauth/v2/accessToken"
+
+
+class LinkedInAPI:
+    """Thin wrapper around the LinkedIn API v2.
+
+    Uses a LinkedIn OAuth 2.0 access token. Obtain one via the 3-legged
+    OAuth flow or by providing LINKEDIN_ACCESS_TOKEN in .env.
+    """
+
+    def __init__(self):
+        self.access_token = os.getenv("LINKEDIN_ACCESS_TOKEN")
+        self.client_id = os.getenv("LINKEDIN_CLIENT_ID")
+        self.client_secret = os.getenv("LINKEDIN_CLIENT_SECRET")
+        self._person_urn: str | None = None
+
+    # ------------------------------------------------------------------
+    # Low-level request helper
+    # ------------------------------------------------------------------
+
+    def _request(
+        self,
+        method: str,
+        endpoint: str,
+        params: dict[str, Any] | None = None,
+        json_body: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        """Send a request to the LinkedIn API."""
+        url = (
+            endpoint
+            if endpoint.startswith("https://")
+            else f"{LINKEDIN_API_BASE}/{endpoint}"
+        )
+        headers = {
+            "Authorization": f"Bearer {self.access_token}",
+            "X-Restli-Protocol-Version": "2.0.0",
+        }
+        if json_body is not None:
+            headers["Content-Type"] = "application/json"
+
+        try:
+            r = requests.request(
+                method, url, headers=headers, params=params, json=json_body, timeout=30
+            )
+        except requests.RequestException as exc:
+            raise RuntimeError(f"LinkedIn API request failed: {exc}") from exc
+
+        if r.status_code == 204:
+            return {"success": True}
+
+        try:
+            result = r.json()
+        except ValueError:
+            raise RuntimeError(
+                f"LinkedIn API returned non-JSON (HTTP {r.status_code}): {r.text[:300]}"
+            )
+
+        if r.status_code not in (200, 201):
+            error_msg = result.get("message", str(result))
+            raise RuntimeError(f"LinkedIn API error (HTTP {r.status_code}): {error_msg}")
+        return result
+
+    # ------------------------------------------------------------------
+    # OAuth helpers
+    # ------------------------------------------------------------------
+
+    def get_auth_url(
+        self,
+        redirect_uri: str,
+        scopes: str = "openid profile email w_member_social",
+    ) -> str:
+        """Return the URL the user should visit to authorise the app.
+
+        After authorising, LinkedIn redirects to redirect_uri with a ?code= param.
+        Pass that code to exchange_code().
+        """
+        return (
+            f"{LINKEDIN_AUTH_URL}"
+            f"?response_type=code"
+            f"&client_id={self.client_id}"
+            f"&redirect_uri={redirect_uri}"
+            f"&scope={scopes}"
+        )
+
+    def exchange_code(self, code: str, redirect_uri: str) -> dict[str, Any]:
+        """Exchange an authorisation code for an access token (~60 days)."""
+        try:
+            r = requests.post(
+                LINKEDIN_TOKEN_URL,
+                data={
+                    "grant_type": "authorization_code",
+                    "code": code,
+                    "client_id": self.client_id,
+                    "client_secret": self.client_secret,
+                    "redirect_uri": redirect_uri,
+                },
+                timeout=30,
+            )
+        except requests.RequestException as exc:
+            return {"success": False, "error": str(exc)}
+
+        try:
+            result = r.json()
+        except ValueError:
+            return {"success": False, "error": f"Non-JSON response: {r.text[:200]}"}
+
+        if "access_token" in result:
+            self.access_token = result["access_token"]
+        return result
+
+    def refresh_token(self, refresh_token: str) -> dict[str, Any]:
+        """Refresh an access token using a refresh token.
+
+        LinkedIn refresh tokens are available only for apps approved for
+        the 'r_basicprofile' or marketing APIs. Returns the new token pair.
+        """
+        try:
+            r = requests.post(
+                LINKEDIN_TOKEN_URL,
+                data={
+                    "grant_type": "refresh_token",
+                    "refresh_token": refresh_token,
+                    "client_id": self.client_id,
+                    "client_secret": self.client_secret,
+                },
+                timeout=30,
+            )
+        except requests.RequestException as exc:
+            return {"success": False, "error": str(exc)}
+
+        try:
+            result = r.json()
+        except ValueError:
+            return {"success": False, "error": f"Non-JSON response: {r.text[:200]}"}
+
+        if "access_token" in result:
+            self.access_token = result["access_token"]
+        return result
+
+    # ------------------------------------------------------------------
+    # Connection check / profile
+    # ------------------------------------------------------------------
+
+    def get_profile(self) -> dict[str, Any]:
+        """Return the LinkedIn profile for the authenticated user.
+
+        Uses the OpenID Connect userinfo endpoint which returns sub, name,
+        email, and picture.
+        """
+        if not self.access_token:
+            return {"connected": False, "error": "LINKEDIN_ACCESS_TOKEN not set"}
+        try:
+            result = self._request("GET", "https://api.linkedin.com/v2/userinfo")
+            # The 'sub' field is the member's person ID
+            person_id = result.get("sub", "")
+            self._person_urn = f"urn:li:person:{person_id}"
+            return {
+                "connected": True,
+                "id": person_id,
+                "name": result.get("name", ""),
+                "email": result.get("email", ""),
+                "picture": result.get("picture", ""),
+                "given_name": result.get("given_name", ""),
+                "family_name": result.get("family_name", ""),
+            }
+        except Exception as exc:
+            return {"connected": False, "error": str(exc)}
+
+    @property
+    def person_urn(self) -> str:
+        """Lazy-load the LinkedIn person URN (urn:li:person:xxx)."""
+        if self._person_urn is None:
+            info = self.get_profile()
+            if not info.get("connected"):
+                raise RuntimeError(info.get("error", "LinkedIn not connected"))
+        return self._person_urn  # type: ignore[return-value]
+
+    # ------------------------------------------------------------------
+    # Publishing
+    # ------------------------------------------------------------------
+
+    def post_text(self, text: str) -> dict[str, Any]:
+        """Publish a text-only post to the user's LinkedIn feed.
+
+        Uses the UGC Post API (v2).
+        """
+        author = self.person_urn
+        payload = {
+            "author": author,
+            "lifecycleState": "PUBLISHED",
+            "specificContent": {
+                "com.linkedin.ugc.ShareContent": {
+                    "shareCommentary": {"text": text},
+                    "shareMediaCategory": "NONE",
+                }
+            },
+            "visibility": {
+                "com.linkedin.ugc.MemberNetworkVisibility": "PUBLIC"
+            },
+        }
+        try:
+            result = self._request("POST", "ugcPosts", json_body=payload)
+            post_id = result.get("id", "")
+            return {"success": True, "id": post_id}
+        except Exception as exc:
+            return {"success": False, "error": str(exc)}
+
+    def post_image(self, image_url: str, text: str = "") -> dict[str, Any]:
+        """Share an image post with optional text on LinkedIn.
+
+        LinkedIn requires images to be uploaded via their image upload API.
+        For simplicity this method uses an external image URL as a thumbnail
+        via the article share type, which supports external URLs directly.
+        For native image uploads, use the register/upload flow instead.
+        """
+        author = self.person_urn
+        media_entry: dict[str, Any] = {
+            "status": "READY",
+            "originalUrl": image_url,
+            "description": {"text": text or "Shared image"},
+        }
+        if text:
+            media_entry["title"] = {"text": text[:200]}
+
+        payload = {
+            "author": author,
+            "lifecycleState": "PUBLISHED",
+            "specificContent": {
+                "com.linkedin.ugc.ShareContent": {
+                    "shareCommentary": {"text": text},
+                    "shareMediaCategory": "IMAGE",
+                    "media": [media_entry],
+                }
+            },
+            "visibility": {
+                "com.linkedin.ugc.MemberNetworkVisibility": "PUBLIC"
+            },
+        }
+        try:
+            result = self._request("POST", "ugcPosts", json_body=payload)
+            post_id = result.get("id", "")
+            return {"success": True, "id": post_id}
+        except Exception as exc:
+            return {"success": False, "error": str(exc)}
+
+    def post_article(self, article_url: str, text: str = "") -> dict[str, Any]:
+        """Share a link/article on LinkedIn with optional commentary text.
+
+        LinkedIn will automatically unfurl the link and display a preview card.
+        """
+        author = self.person_urn
+        payload = {
+            "author": author,
+            "lifecycleState": "PUBLISHED",
+            "specificContent": {
+                "com.linkedin.ugc.ShareContent": {
+                    "shareCommentary": {"text": text},
+                    "shareMediaCategory": "ARTICLE",
+                    "media": [
+                        {
+                            "status": "READY",
+                            "originalUrl": article_url,
+                        }
+                    ],
+                }
+            },
+            "visibility": {
+                "com.linkedin.ugc.MemberNetworkVisibility": "PUBLIC"
+            },
+        }
+        try:
+            result = self._request("POST", "ugcPosts", json_body=payload)
+            post_id = result.get("id", "")
+            return {"success": True, "id": post_id}
+        except Exception as exc:
+            return {"success": False, "error": str(exc)}
+
+    # ------------------------------------------------------------------
+    # Read operations
+    # ------------------------------------------------------------------
+
+    def get_post(self, post_id: str) -> dict[str, Any]:
+        """Fetch a single UGC post by its ID (URN-encoded)."""
+        try:
+            return self._request("GET", f"ugcPosts/{post_id}")
+        except Exception as exc:
+            return {"success": False, "error": str(exc)}
+
+    def delete_post(self, post_id: str) -> dict[str, Any]:
+        """Delete a UGC post by its ID.
+
+        post_id should be the full URN, e.g. urn:li:ugcPost:12345
+        """
+        try:
+            return self._request("DELETE", f"ugcPosts/{post_id}")
+        except Exception as exc:
+            return {"success": False, "error": str(exc)}

--- a/manager.py
+++ b/manager.py
@@ -3,6 +3,9 @@ from facebook_api import FacebookAPI
 from instagram_api import InstagramAPI
 from whatsapp_api import WhatsAppAPI
 from threads_api import ThreadsAPI
+from linkedin_api import LinkedInAPI
+from tiktok_api import TikTokAPI
+from youtube_api import YouTubeAPI
 
 
 class Manager:
@@ -11,6 +14,9 @@ class Manager:
         self.ig = InstagramAPI()
         self.wa = WhatsAppAPI()
         self.threads = ThreadsAPI()
+        self.linkedin = LinkedInAPI()
+        self.tiktok = TikTokAPI()
+        self.youtube = YouTubeAPI()
 
     def post_to_facebook(self, message: str) -> dict[str, Any]:
         return self.api.post_message(message)
@@ -219,6 +225,74 @@ class Manager:
 
     def get_scheduled_posts(self) -> dict[str, Any]:
         return self.api.get_scheduled_posts()
+
+    # --- LinkedIn passthroughs ---
+    def get_linkedin_profile(self) -> dict[str, Any]:
+        return self.linkedin.get_profile()
+
+    def post_to_linkedin(self, message: str, image_url: str | None = None, article_url: str | None = None) -> dict[str, Any]:
+        if image_url:
+            return self.linkedin.post_image(image_url, message)
+        if article_url:
+            return self.linkedin.post_article(article_url, message)
+        return self.linkedin.post_text(message)
+
+    def post_image_to_linkedin(self, image_url: str, text: str = "") -> dict[str, Any]:
+        return self.linkedin.post_image(image_url, text)
+
+    def post_article_to_linkedin(self, article_url: str, text: str = "") -> dict[str, Any]:
+        return self.linkedin.post_article(article_url, text)
+
+    def delete_linkedin_post(self, post_id: str) -> dict[str, Any]:
+        return self.linkedin.delete_post(post_id)
+
+    # --- TikTok passthroughs ---
+    def get_tiktok_profile(self) -> dict[str, Any]:
+        return self.tiktok.get_profile()
+
+    def post_to_tiktok(
+        self,
+        video_url: str | None = None,
+        video_path: str | None = None,
+    ) -> dict[str, Any]:
+        """Push a video to the user's TikTok inbox / drafts.
+
+        The user finalises and publishes from the TikTok app itself.
+        This is the inbox-upload tier; direct publishing requires the
+        video.publish scope and full app review.
+        """
+        return self.tiktok.upload_to_inbox(video_url=video_url, video_path=video_path)
+
+    def get_tiktok_publish_status(self, publish_id: str) -> dict[str, Any]:
+        return self.tiktok.get_publish_status(publish_id)
+
+    # --- YouTube passthroughs ---
+    def get_youtube_channel_info(self) -> dict[str, Any]:
+        return self.youtube.get_channel_info()
+
+    def post_to_youtube(
+        self,
+        video_path: str,
+        title: str,
+        description: str = "",
+        tags: list[str] | None = None,
+        privacy_status: str = "private",
+    ) -> dict[str, Any]:
+        """Upload a local video to the authenticated user's channel.
+
+        Defaults privacy_status='private'. The user can switch to public
+        from the dashboard once they have reviewed the upload.
+        """
+        return self.youtube.upload_video(
+            video_path=video_path,
+            title=title,
+            description=description,
+            tags=tags,
+            privacy_status=privacy_status,
+        )
+
+    def delete_youtube_video(self, video_id: str) -> dict[str, Any]:
+        return self.youtube.delete_video(video_id)
 
     def get_page_info(self) -> dict[str, Any]:
         return self.api.get_page_info()

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,5 @@ fastapi
 uvicorn[standard]
 jinja2
 python-multipart
+apscheduler>=3.10,<4
+sqlalchemy>=2.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,37 @@
+"""Shared pytest fixtures.
+
+We isolate every test from the user's real `~/.social-auto-engine/` directory
+by pointing the dashboard at a temporary database before any module imports.
+"""
+from __future__ import annotations
+
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+
+# Ensure the project root is importable as a package
+ROOT = Path(__file__).resolve().parent.parent
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+
+@pytest.fixture(autouse=True)
+def isolated_dashboard_db(monkeypatch, tmp_path):
+    """Redirect the dashboard's SQLite db to a tmp file for each test."""
+    db_dir = tmp_path / ".social-auto-engine"
+    db_dir.mkdir(exist_ok=True)
+    db_path = db_dir / "dashboard.db"
+
+    # Patch the module-level path constants the dashboard's db uses
+    from dashboard import db as dash_db
+
+    monkeypatch.setattr(dash_db, "DB_DIR", db_dir)
+    monkeypatch.setattr(dash_db, "DB_PATH", db_path)
+
+    # Force the schema in the new db
+    dash_db.init_db()
+    yield db_path

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,9 +5,7 @@ by pointing the dashboard at a temporary database before any module imports.
 """
 from __future__ import annotations
 
-import os
 import sys
-import tempfile
 from pathlib import Path
 
 import pytest

--- a/tests/test_adapters_smoke.py
+++ b/tests/test_adapters_smoke.py
@@ -1,0 +1,98 @@
+"""Adapter import / instantiation smoke tests.
+
+These never call out to a real platform API. They confirm:
+  - the modules import without errors
+  - the classes can be instantiated with no env vars set
+  - the safe-failure behaviour returns a connected=False dict, never crashes
+"""
+from __future__ import annotations
+
+import pytest
+
+
+def test_facebook_adapter_imports():
+    from facebook_api import FacebookAPI
+
+    api = FacebookAPI()
+    assert api is not None
+
+
+def test_instagram_adapter_imports():
+    from instagram_api import InstagramAPI
+
+    api = InstagramAPI()
+    assert api is not None
+
+
+def test_whatsapp_adapter_imports():
+    from whatsapp_api import WhatsAppAPI
+
+    api = WhatsAppAPI()
+    assert api is not None
+
+
+def test_threads_adapter_imports():
+    from threads_api import ThreadsAPI
+
+    api = ThreadsAPI()
+    assert api is not None
+
+
+def test_linkedin_adapter_imports_and_safe_failure():
+    from linkedin_api import LinkedInAPI
+
+    api = LinkedInAPI()
+    info = api.get_profile()
+    assert info["connected"] is False
+    assert "error" in info
+
+
+def test_tiktok_adapter_imports_and_safe_failure():
+    from tiktok_api import TikTokAPI
+
+    api = TikTokAPI()
+    info = api.get_profile()
+    assert info["connected"] is False
+    assert "error" in info
+
+
+def test_youtube_adapter_imports_and_safe_failure():
+    from youtube_api import YouTubeAPI
+
+    api = YouTubeAPI()
+    info = api.get_channel_info()
+    assert info["connected"] is False
+    assert "error" in info
+
+
+def test_manager_wires_every_adapter():
+    """Manager exposes one attribute per adapter, all instantiable together."""
+    from manager import Manager
+
+    m = Manager()
+    assert hasattr(m, "api")
+    assert hasattr(m, "ig")
+    assert hasattr(m, "wa")
+    assert hasattr(m, "threads")
+    assert hasattr(m, "linkedin")
+    assert hasattr(m, "tiktok")
+    assert hasattr(m, "youtube")
+
+
+@pytest.mark.parametrize(
+    "method,kwargs",
+    [
+        ("get_linkedin_profile", {}),
+        ("get_tiktok_profile", {}),
+        ("get_youtube_channel_info", {}),
+    ],
+)
+def test_manager_safe_failure_methods(method, kwargs):
+    """Each safe-failure read returns a connected=False dict, no exception."""
+    from manager import Manager
+
+    m = Manager()
+    fn = getattr(m, method)
+    result = fn(**kwargs)
+    assert isinstance(result, dict)
+    assert result.get("connected") is False

--- a/tests/test_compose.py
+++ b/tests/test_compose.py
@@ -1,0 +1,93 @@
+"""HTTP-level tests for the compose endpoint and the broadcast group flow.
+
+These tests do not exercise any real social-platform API. The publish
+dispatch is mocked via env vars so the dashboard never tries to call out.
+"""
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from dashboard import app as dash_app
+from dashboard import db
+
+
+client = TestClient(dash_app.app)
+
+
+def _post_form(path: str, body: str):
+    return client.post(
+        path,
+        content=body,
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+    )
+
+
+def test_compose_single_platform_legacy_creates_one_row():
+    r = _post_form("/compose", "message=hello&platform=facebook")
+    assert r.status_code == 200
+
+    singles, groups = db.list_pending_grouped()
+    assert len(singles) == 1
+    assert singles[0]["platform"] == "facebook"
+    assert singles[0]["group_id"] is None
+    assert not groups
+
+
+def test_compose_broadcast_two_platforms_creates_one_group_of_two():
+    r = _post_form(
+        "/compose",
+        "message=cross+post&platforms=facebook&platforms=linkedin",
+    )
+    assert r.status_code == 200
+
+    singles, groups = db.list_pending_grouped()
+    assert not singles
+    assert len(groups) == 1
+    assert len(groups[0]) == 2
+    assert {p["platform"] for p in groups[0]} == {"facebook", "linkedin"}
+    # Both rows share the same group_id
+    gids = {p["group_id"] for p in groups[0]}
+    assert len(gids) == 1
+
+
+def test_compose_rejects_whatsapp_combined_with_broadcast():
+    r = _post_form(
+        "/compose",
+        "message=mix&platforms=whatsapp&platforms=facebook&recipient=%2B9725",
+    )
+    assert r.status_code == 400
+
+
+def test_compose_rejects_empty_message():
+    r = _post_form("/compose", "platforms=facebook")
+    assert r.status_code == 400
+
+
+def test_compose_rejects_instagram_without_image():
+    r = _post_form("/compose", "message=hi&platforms=instagram")
+    assert r.status_code == 400
+
+
+def test_compose_rejects_unknown_platform():
+    r = _post_form("/compose", "message=hi&platforms=myspace")
+    assert r.status_code == 400
+
+
+def test_reject_group_marks_all_rows_rejected():
+    _post_form(
+        "/compose",
+        "message=reject+me&platforms=facebook&platforms=linkedin",
+    )
+    singles, groups = db.list_pending_grouped()
+    gid = groups[0][0]["group_id"]
+
+    r = client.post(f"/reject-group/{gid}")
+    assert r.status_code == 200
+
+    rows = db.list_group(gid)
+    assert all(r["status"] == "rejected" for r in rows)
+
+
+def test_reject_group_404_when_group_missing():
+    r = client.post("/reject-group/nonexistent-uuid")
+    assert r.status_code == 404

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -1,0 +1,97 @@
+"""Persistence tests for the dashboard's SQLite layer."""
+from __future__ import annotations
+
+from dashboard import db
+
+
+def test_init_db_creates_post_table_with_group_id():
+    """The migration must add group_id to existing schemas and ship it on new ones."""
+    with db.connect() as conn:
+        cols = {r[1] for r in conn.execute("PRAGMA table_info(post)")}
+    assert "group_id" in cols
+    assert "platform" in cols
+    assert "status" in cols
+
+
+def test_create_post_returns_id_and_persists_row():
+    pid = db.create_post(
+        message="hello world",
+        account_name="Hack-Tech",
+        platform="facebook",
+    )
+    assert isinstance(pid, int) and pid > 0
+
+    row = db.get_post(pid)
+    assert row is not None
+    assert row["message"] == "hello world"
+    assert row["platform"] == "facebook"
+    assert row["status"] == "pending"
+    assert row["group_id"] is None  # legacy single-platform posts have no group
+
+
+def test_create_broadcast_creates_n_rows_with_shared_group_id():
+    targets = [
+        {"platform": "facebook", "account_name": "Hack-Tech"},
+        {"platform": "instagram", "account_name": "Instagram"},
+        {"platform": "linkedin", "account_name": "LinkedIn"},
+    ]
+    result = db.create_broadcast(
+        message="multi-platform launch",
+        targets=targets,
+        image_url="https://example.com/x.jpg",
+    )
+    assert "group_id" in result and result["group_id"]
+    assert len(result["post_ids"]) == 3
+
+    rows = db.list_group(result["group_id"])
+    assert len(rows) == 3
+    assert {r["platform"] for r in rows} == {"facebook", "instagram", "linkedin"}
+    assert all(r["status"] == "pending" for r in rows)
+    assert all(r["group_id"] == result["group_id"] for r in rows)
+    assert all(r["image_url"] == "https://example.com/x.jpg" for r in rows)
+
+
+def test_create_broadcast_rejects_empty_targets():
+    import pytest
+
+    with pytest.raises(ValueError):
+        db.create_broadcast(message="x", targets=[])
+
+
+def test_list_pending_grouped_separates_singles_and_groups():
+    db.create_post(message="single fb", platform="facebook")
+    db.create_broadcast(
+        message="broadcast",
+        targets=[
+            {"platform": "facebook", "account_name": "Hack-Tech"},
+            {"platform": "linkedin", "account_name": "LinkedIn"},
+        ],
+    )
+    db.create_post(message="single ig", platform="instagram", image_url="https://x/y")
+
+    singles, groups = db.list_pending_grouped()
+    assert len(singles) == 2
+    assert {s["platform"] for s in singles} == {"facebook", "instagram"}
+    assert all(s["group_id"] is None for s in singles)
+
+    assert len(groups) == 1
+    assert len(groups[0]) == 2
+    assert {p["platform"] for p in groups[0]} == {"facebook", "linkedin"}
+
+
+def test_mark_published_and_mark_failed_set_decision_timestamps():
+    pid = db.create_post(message="x", platform="facebook")
+    db.mark_published(pid, platform_post_id="fb_123", permalink_url="https://fb/1")
+    row = db.get_post(pid)
+    assert row["status"] == "published"
+    assert row["platform_post_id"] == "fb_123"
+    assert row["permalink_url"] == "https://fb/1"
+    assert row["published_at"] is not None
+    assert row["decided_at"] is not None
+
+    pid2 = db.create_post(message="y", platform="facebook")
+    db.mark_failed(pid2, error_message="token expired")
+    row2 = db.get_post(pid2)
+    assert row2["status"] == "failed"
+    assert row2["error_message"] == "token expired"
+    assert row2["decided_at"] is not None

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -125,3 +125,39 @@ def test_store_tokens_skips_empty_values(tmp_path, monkeypatch):
 
     contents = fake_tokens.read_text(encoding="utf-8")
     assert "LINKEDIN_ACCESS_TOKEN=real" in contents
+
+
+# ---------------------------------------------------------------------------
+# Disconnect endpoint
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("platform", ["linkedin", "tiktok", "youtube"])
+def test_disconnect_redirects_to_settings(platform):
+    r = client.post(f"/oauth/{platform}/disconnect", follow_redirects=False)
+    assert r.status_code == 303
+    assert r.headers["location"].endswith("/settings")
+
+
+def test_disconnect_unknown_platform_404():
+    r = client.post("/oauth/myspace/disconnect")
+    assert r.status_code == 404
+
+
+def test_disconnect_clears_token_from_disk_and_adapter(tmp_path, monkeypatch):
+    fake_tokens = tmp_path / ".social-auto-engine" / "tokens.env"
+    monkeypatch.setattr(dash_app, "TOKENS_PATH", fake_tokens)
+
+    dash_app._store_tokens({"LINKEDIN_ACCESS_TOKEN": "should-be-cleared"})
+    assert dash_app.fb.linkedin.access_token == "should-be-cleared"
+
+    fresh_client = TestClient(dash_app.app)
+    r = fresh_client.post("/oauth/linkedin/disconnect", follow_redirects=False)
+    assert r.status_code == 303
+
+    # Disk should no longer contain the cleared key
+    if fake_tokens.exists():
+        contents = fake_tokens.read_text(encoding="utf-8")
+        assert "LINKEDIN_ACCESS_TOKEN=" not in contents
+
+    # Adapter should be cleared
+    assert dash_app.fb.linkedin.access_token is None

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -1,0 +1,127 @@
+"""Tests for the OAuth callback flow shared by LinkedIn, TikTok, and YouTube.
+
+These never call out to a real provider. They confirm:
+  - /oauth/<platform>/start sets a state cookie and 303-redirects to the provider
+  - the callback returns 400 for missing code, missing state cookie, or state mismatch
+  - _store_tokens persists key=value pairs to ~/.social-auto-engine/tokens.env
+    AND patches the live adapter instances
+"""
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+from dashboard import app as dash_app
+
+
+client = TestClient(dash_app.app)
+
+
+# ---------------------------------------------------------------------------
+# Start endpoints
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize(
+    "platform,host_substring",
+    [
+        ("linkedin", "linkedin.com"),
+        ("tiktok", "tiktok.com"),
+        ("youtube", "google.com"),
+    ],
+)
+def test_oauth_start_redirects_to_provider(platform, host_substring):
+    r = client.get(f"/oauth/{platform}/start", follow_redirects=False)
+    assert r.status_code in (302, 303, 307)
+    assert host_substring in r.headers["location"]
+
+
+@pytest.mark.parametrize("platform", ["linkedin", "tiktok", "youtube"])
+def test_oauth_start_sets_state_cookie(platform):
+    r = client.get(f"/oauth/{platform}/start", follow_redirects=False)
+    cookies = r.cookies
+    assert f"{platform}_oauth_state" in cookies
+    state = cookies[f"{platform}_oauth_state"]
+    assert state and len(state) >= 16
+
+
+# ---------------------------------------------------------------------------
+# Callback rejection paths
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("platform", ["linkedin", "tiktok", "youtube"])
+def test_oauth_callback_rejects_missing_code(platform):
+    r = client.get(f"/oauth/{platform}/callback")
+    assert r.status_code == 400
+
+
+@pytest.mark.parametrize("platform", ["linkedin", "tiktok", "youtube"])
+def test_oauth_callback_rejects_missing_state_cookie(platform):
+    """A code without a matching state cookie is a CSRF risk."""
+    r = client.get(f"/oauth/{platform}/callback?code=abc&state=xyz")
+    assert r.status_code == 400
+    assert "state" in r.text.lower() or "oauth" in r.text.lower()
+
+
+@pytest.mark.parametrize("platform", ["linkedin", "tiktok", "youtube"])
+def test_oauth_callback_rejects_state_mismatch(platform):
+    fresh_client = TestClient(dash_app.app)
+    fresh_client.cookies.set(f"{platform}_oauth_state", "expected_value")
+    r = fresh_client.get(f"/oauth/{platform}/callback?code=abc&state=different_value")
+    assert r.status_code == 400
+
+
+@pytest.mark.parametrize("platform", ["linkedin", "tiktok", "youtube"])
+def test_oauth_callback_rejects_provider_error(platform):
+    fresh_client = TestClient(dash_app.app)
+    r = fresh_client.get(f"/oauth/{platform}/callback?error=access_denied")
+    assert r.status_code == 400
+
+
+# ---------------------------------------------------------------------------
+# _store_tokens helper
+# ---------------------------------------------------------------------------
+
+def test_store_tokens_writes_to_disk_and_patches_adapter(tmp_path, monkeypatch):
+    """_store_tokens should both persist to disk and update the running adapter."""
+    fake_tokens = tmp_path / ".social-auto-engine" / "tokens.env"
+    monkeypatch.setattr(dash_app, "TOKENS_PATH", fake_tokens)
+
+    dash_app._store_tokens({"LINKEDIN_ACCESS_TOKEN": "secret-token-123"})
+
+    # Disk
+    assert fake_tokens.exists()
+    contents = fake_tokens.read_text(encoding="utf-8")
+    assert "LINKEDIN_ACCESS_TOKEN=secret-token-123" in contents
+
+    # Live adapter
+    assert dash_app.fb.linkedin.access_token == "secret-token-123"
+
+    # Live env
+    import os
+
+    assert os.environ.get("LINKEDIN_ACCESS_TOKEN") == "secret-token-123"
+
+
+def test_store_tokens_merges_with_existing_file(tmp_path, monkeypatch):
+    """A second call should preserve unrelated keys from the first."""
+    fake_tokens = tmp_path / ".social-auto-engine" / "tokens.env"
+    monkeypatch.setattr(dash_app, "TOKENS_PATH", fake_tokens)
+
+    dash_app._store_tokens({"LINKEDIN_ACCESS_TOKEN": "first"})
+    dash_app._store_tokens({"TIKTOK_ACCESS_TOKEN": "second"})
+
+    contents = fake_tokens.read_text(encoding="utf-8")
+    assert "LINKEDIN_ACCESS_TOKEN=first" in contents
+    assert "TIKTOK_ACCESS_TOKEN=second" in contents
+
+
+def test_store_tokens_skips_empty_values(tmp_path, monkeypatch):
+    """An empty value should not overwrite an existing key."""
+    fake_tokens = tmp_path / ".social-auto-engine" / "tokens.env"
+    monkeypatch.setattr(dash_app, "TOKENS_PATH", fake_tokens)
+
+    dash_app._store_tokens({"LINKEDIN_ACCESS_TOKEN": "real"})
+    dash_app._store_tokens({"LINKEDIN_ACCESS_TOKEN": ""})
+
+    contents = fake_tokens.read_text(encoding="utf-8")
+    assert "LINKEDIN_ACCESS_TOKEN=real" in contents

--- a/tiktok_api.py
+++ b/tiktok_api.py
@@ -1,0 +1,313 @@
+"""TikTok Content Posting API adapter.
+
+TikTok has its own OAuth 2.0 flow via tiktok.com and its own API host at
+open.tiktokapis.com. The Content Posting API has two tiers:
+
+  - Inbox upload (video.upload scope): pushes the video to the user's
+    TikTok drafts. The user opens TikTok, edits if they want, and taps
+    publish. This tier is approvable without the heavy review process.
+  - Direct post  (video.publish scope): publishes immediately. Requires
+    full app review and is harder to obtain. Saved for a later iteration.
+
+This adapter ships with the inbox-upload flow.
+
+Permissions:
+  - user.info.basic   (read profile basics)
+  - user.info.profile (read full profile)
+  - video.upload      (inbox upload)
+  - video.list        (read user's videos, optional)
+
+Rate limits:
+  - Inbox-upload init: 6 requests per minute per user access token
+  - Maximum 5 pending drafts in any 24-hour rolling window
+
+Note: PULL_FROM_URL requires the source domain to be pre-verified in the
+TikTok developer portal. For users without a verified domain, supply a
+local file path and the adapter will use the chunked FILE_UPLOAD flow.
+"""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Any
+
+import requests
+
+
+TIKTOK_API_BASE = "https://open.tiktokapis.com/v2"
+TIKTOK_AUTH_URL = "https://www.tiktok.com/v2/auth/authorize/"
+TIKTOK_TOKEN_URL = "https://open.tiktokapis.com/v2/oauth/token/"
+
+UPLOAD_CHUNK_SIZE = 10 * 1024 * 1024  # 10 MB
+
+
+class TikTokAPI:
+    """Thin wrapper around the TikTok Content Posting API (inbox tier)."""
+
+    def __init__(self):
+        self.access_token = os.getenv("TIKTOK_ACCESS_TOKEN")
+        self.client_key = os.getenv("TIKTOK_CLIENT_KEY")
+        self.client_secret = os.getenv("TIKTOK_CLIENT_SECRET")
+
+    # ------------------------------------------------------------------
+    # Low-level request helper
+    # ------------------------------------------------------------------
+
+    def _request(
+        self,
+        method: str,
+        endpoint: str,
+        params: dict[str, Any] | None = None,
+        json_body: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        url = (
+            endpoint
+            if endpoint.startswith("https://")
+            else f"{TIKTOK_API_BASE}/{endpoint}"
+        )
+        headers = {
+            "Authorization": f"Bearer {self.access_token}",
+            "Content-Type": "application/json; charset=UTF-8",
+        }
+        try:
+            r = requests.request(
+                method, url, headers=headers, params=params, json=json_body, timeout=30
+            )
+        except requests.RequestException as exc:
+            raise RuntimeError(f"TikTok API request failed: {exc}") from exc
+
+        try:
+            result = r.json()
+        except ValueError:
+            raise RuntimeError(
+                f"TikTok API returned non-JSON (HTTP {r.status_code}): {r.text[:300]}"
+            )
+
+        # TikTok returns errors inside an "error" envelope even on 200s
+        err = result.get("error") or {}
+        code = err.get("code", "ok")
+        if r.status_code not in (200, 201) or (code and code != "ok"):
+            raise RuntimeError(
+                f"TikTok API error (HTTP {r.status_code}, code {code}): "
+                f"{err.get('message', str(result))}"
+            )
+        return result
+
+    # ------------------------------------------------------------------
+    # OAuth helpers
+    # ------------------------------------------------------------------
+
+    def get_auth_url(
+        self,
+        redirect_uri: str,
+        scopes: str = "user.info.basic,user.info.profile,video.upload,video.list",
+        state: str = "",
+    ) -> str:
+        """Return the URL the user should visit to authorise the app."""
+        return (
+            f"{TIKTOK_AUTH_URL}"
+            f"?client_key={self.client_key}"
+            f"&response_type=code"
+            f"&scope={scopes}"
+            f"&redirect_uri={redirect_uri}"
+            f"&state={state}"
+        )
+
+    def exchange_code(self, code: str, redirect_uri: str) -> dict[str, Any]:
+        """Exchange an authorisation code for an access token."""
+        try:
+            r = requests.post(
+                TIKTOK_TOKEN_URL,
+                data={
+                    "client_key": self.client_key,
+                    "client_secret": self.client_secret,
+                    "code": code,
+                    "grant_type": "authorization_code",
+                    "redirect_uri": redirect_uri,
+                },
+                headers={"Content-Type": "application/x-www-form-urlencoded"},
+                timeout=30,
+            )
+        except requests.RequestException as exc:
+            return {"success": False, "error": str(exc)}
+
+        try:
+            result = r.json()
+        except ValueError:
+            return {"success": False, "error": f"Non-JSON response: {r.text[:200]}"}
+
+        if "access_token" in result:
+            self.access_token = result["access_token"]
+        return result
+
+    def refresh_access_token(self, refresh_token: str) -> dict[str, Any]:
+        """Refresh an access token using a refresh token."""
+        try:
+            r = requests.post(
+                TIKTOK_TOKEN_URL,
+                data={
+                    "client_key": self.client_key,
+                    "client_secret": self.client_secret,
+                    "grant_type": "refresh_token",
+                    "refresh_token": refresh_token,
+                },
+                headers={"Content-Type": "application/x-www-form-urlencoded"},
+                timeout=30,
+            )
+        except requests.RequestException as exc:
+            return {"success": False, "error": str(exc)}
+
+        try:
+            result = r.json()
+        except ValueError:
+            return {"success": False, "error": f"Non-JSON response: {r.text[:200]}"}
+
+        if "access_token" in result:
+            self.access_token = result["access_token"]
+        return result
+
+    # ------------------------------------------------------------------
+    # Profile
+    # ------------------------------------------------------------------
+
+    def get_profile(self) -> dict[str, Any]:
+        """Return the authenticated TikTok user's basic profile info."""
+        if not self.access_token:
+            return {"connected": False, "error": "TIKTOK_ACCESS_TOKEN not set"}
+        try:
+            result = self._request(
+                "GET",
+                "user/info/",
+                params={
+                    "fields": "open_id,union_id,avatar_url,display_name,username,follower_count"
+                },
+            )
+            user = result.get("data", {}).get("user", {})
+            return {
+                "connected": True,
+                "id": user.get("open_id", ""),
+                "name": user.get("display_name", ""),
+                "username": user.get("username", ""),
+                "avatar_url": user.get("avatar_url", ""),
+                "follower_count": user.get("follower_count", 0),
+            }
+        except Exception as exc:
+            return {"connected": False, "error": str(exc)}
+
+    # ------------------------------------------------------------------
+    # Inbox upload
+    # ------------------------------------------------------------------
+
+    def upload_to_inbox(
+        self,
+        video_url: str | None = None,
+        video_path: str | None = None,
+    ) -> dict[str, Any]:
+        """Push a video to the user's TikTok inbox / drafts.
+
+        Pass either:
+          - video_url: must be a publicly reachable URL on a domain that has
+            been pre-verified in the TikTok developer portal.
+          - video_path: a local file path. The adapter will read it and use
+            the chunked FILE_UPLOAD flow.
+
+        After this returns, the user opens the TikTok app, taps the inbox
+        notification, and finalises the post themselves. We never publish
+        without their final tap.
+        """
+        if not video_url and not video_path:
+            return {"success": False, "error": "Pass either video_url or video_path"}
+        if video_url and video_path:
+            return {"success": False, "error": "Pass either video_url or video_path, not both"}
+
+        if video_url:
+            return self._init_pull_from_url(video_url)
+        return self._init_and_upload_file(video_path)
+
+    def _init_pull_from_url(self, video_url: str) -> dict[str, Any]:
+        try:
+            result = self._request(
+                "POST",
+                "post/publish/inbox/video/init/",
+                json_body={
+                    "source_info": {
+                        "source": "PULL_FROM_URL",
+                        "video_url": video_url,
+                    }
+                },
+            )
+            publish_id = result.get("data", {}).get("publish_id", "")
+            return {"success": True, "id": publish_id, "mode": "pull_from_url"}
+        except Exception as exc:
+            return {"success": False, "error": str(exc)}
+
+    def _init_and_upload_file(self, video_path: str) -> dict[str, Any]:
+        path = Path(video_path).expanduser().resolve()
+        if not path.exists() or not path.is_file():
+            return {"success": False, "error": f"Video file not found: {video_path}"}
+
+        size = path.stat().st_size
+        chunk_size = min(UPLOAD_CHUNK_SIZE, size)
+        total_chunks = max(1, (size + chunk_size - 1) // chunk_size)
+
+        try:
+            init = self._request(
+                "POST",
+                "post/publish/inbox/video/init/",
+                json_body={
+                    "source_info": {
+                        "source": "FILE_UPLOAD",
+                        "video_size": size,
+                        "chunk_size": chunk_size,
+                        "total_chunk_count": total_chunks,
+                    }
+                },
+            )
+        except Exception as exc:
+            return {"success": False, "error": f"Init failed: {exc}"}
+
+        publish_id = init.get("data", {}).get("publish_id", "")
+        upload_url = init.get("data", {}).get("upload_url", "")
+        if not upload_url:
+            return {"success": False, "error": "No upload_url returned from init"}
+
+        try:
+            with path.open("rb") as fh:
+                offset = 0
+                while offset < size:
+                    chunk = fh.read(chunk_size)
+                    if not chunk:
+                        break
+                    last = offset + len(chunk) - 1
+                    headers = {
+                        "Content-Type": "video/mp4",
+                        "Content-Length": str(len(chunk)),
+                        "Content-Range": f"bytes {offset}-{last}/{size}",
+                    }
+                    r = requests.put(upload_url, data=chunk, headers=headers, timeout=120)
+                    if r.status_code not in (200, 201, 206):
+                        return {
+                            "success": False,
+                            "error": f"Chunk upload HTTP {r.status_code}: {r.text[:200]}",
+                        }
+                    offset += len(chunk)
+        except Exception as exc:
+            return {"success": False, "error": f"Chunk upload failed: {exc}"}
+
+        return {"success": True, "id": publish_id, "mode": "file_upload"}
+
+    # ------------------------------------------------------------------
+    # Status polling
+    # ------------------------------------------------------------------
+
+    def get_publish_status(self, publish_id: str) -> dict[str, Any]:
+        """Poll the publish status of a previously-initiated upload."""
+        try:
+            result = self._request(
+                "POST",
+                "post/publish/status/fetch/",
+                json_body={"publish_id": publish_id},
+            )
+            return result.get("data", {})
+        except Exception as exc:
+            return {"success": False, "error": str(exc)}

--- a/tiktok_api.py
+++ b/tiktok_api.py
@@ -247,6 +247,8 @@ class TikTokAPI:
             return {"success": False, "error": f"Video file not found: {video_path}"}
 
         size = path.stat().st_size
+        if size == 0:
+            return {"success": False, "error": "Video file is empty (0 bytes)"}
         chunk_size = min(UPLOAD_CHUNK_SIZE, size)
         total_chunks = max(1, (size + chunk_size - 1) // chunk_size)
 

--- a/youtube_api.py
+++ b/youtube_api.py
@@ -1,0 +1,312 @@
+"""YouTube Data API v3 adapter.
+
+YouTube uses Google OAuth 2.0 and the Google APIs at googleapis.com.
+This adapter implements:
+
+  - 3-legged OAuth (auth URL, code exchange, refresh)
+  - Channel info read
+  - Video upload via simple multipart (suitable for files up to ~128 MB,
+    which covers virtually all social-media video lengths). Resumable
+    upload is a follow-up if anyone hits the cap.
+
+Permissions:
+  - youtube.upload    (upload videos)
+  - youtube.readonly  (read channel info, optional)
+
+Quota cost:
+  - videos.insert: 100 units per upload
+  - Default daily quota: 10,000 units → 100 uploads/day per project
+  - Increase via Google Cloud quota request when needed
+
+Notes on Shorts:
+  YouTube auto-detects Shorts based on aspect ratio (9:16) and duration
+  (≤ 60 seconds). There is no separate "is_short" API flag. Pass a vertical
+  video under 60 seconds and YouTube treats it as a Short.
+"""
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+import requests
+
+
+YOUTUBE_AUTH_URL = "https://accounts.google.com/o/oauth2/v2/auth"
+YOUTUBE_TOKEN_URL = "https://oauth2.googleapis.com/token"
+YOUTUBE_API_BASE = "https://www.googleapis.com/youtube/v3"
+YOUTUBE_UPLOAD_URL = "https://www.googleapis.com/upload/youtube/v3/videos"
+
+
+class YouTubeAPI:
+    """Thin wrapper around the YouTube Data API v3."""
+
+    def __init__(self):
+        self.access_token = os.getenv("YOUTUBE_ACCESS_TOKEN")
+        self.refresh_token = os.getenv("YOUTUBE_REFRESH_TOKEN")
+        self.client_id = os.getenv("YOUTUBE_CLIENT_ID") or os.getenv("GOOGLE_CLIENT_ID")
+        self.client_secret = os.getenv("YOUTUBE_CLIENT_SECRET") or os.getenv("GOOGLE_CLIENT_SECRET")
+
+    # ------------------------------------------------------------------
+    # OAuth helpers
+    # ------------------------------------------------------------------
+
+    def get_auth_url(
+        self,
+        redirect_uri: str,
+        scopes: str = "https://www.googleapis.com/auth/youtube.upload https://www.googleapis.com/auth/youtube.readonly",
+        state: str = "",
+    ) -> str:
+        """Return the URL the user should visit to authorise the app.
+
+        access_type=offline + prompt=consent ensures we get a refresh_token
+        on first authorisation, which we need because access_tokens expire
+        in 1 hour.
+        """
+        params = {
+            "client_id": self.client_id or "",
+            "redirect_uri": redirect_uri,
+            "response_type": "code",
+            "scope": scopes,
+            "access_type": "offline",
+            "prompt": "consent",
+            "state": state,
+        }
+        from urllib.parse import urlencode
+
+        return f"{YOUTUBE_AUTH_URL}?{urlencode(params)}"
+
+    def exchange_code(self, code: str, redirect_uri: str) -> dict[str, Any]:
+        """Exchange an auth code for access + refresh tokens."""
+        try:
+            r = requests.post(
+                YOUTUBE_TOKEN_URL,
+                data={
+                    "code": code,
+                    "client_id": self.client_id,
+                    "client_secret": self.client_secret,
+                    "redirect_uri": redirect_uri,
+                    "grant_type": "authorization_code",
+                },
+                timeout=30,
+            )
+        except requests.RequestException as exc:
+            return {"success": False, "error": str(exc)}
+
+        try:
+            result = r.json()
+        except ValueError:
+            return {"success": False, "error": f"Non-JSON response: {r.text[:200]}"}
+
+        if "access_token" in result:
+            self.access_token = result["access_token"]
+        if "refresh_token" in result:
+            self.refresh_token = result["refresh_token"]
+        return result
+
+    def refresh_access_token(self) -> dict[str, Any]:
+        """Use the stored refresh_token to get a new access_token."""
+        if not self.refresh_token:
+            return {"success": False, "error": "No refresh_token available"}
+        try:
+            r = requests.post(
+                YOUTUBE_TOKEN_URL,
+                data={
+                    "client_id": self.client_id,
+                    "client_secret": self.client_secret,
+                    "refresh_token": self.refresh_token,
+                    "grant_type": "refresh_token",
+                },
+                timeout=30,
+            )
+        except requests.RequestException as exc:
+            return {"success": False, "error": str(exc)}
+
+        try:
+            result = r.json()
+        except ValueError:
+            return {"success": False, "error": f"Non-JSON response: {r.text[:200]}"}
+
+        if "access_token" in result:
+            self.access_token = result["access_token"]
+        return result
+
+    # ------------------------------------------------------------------
+    # Channel info
+    # ------------------------------------------------------------------
+
+    def get_channel_info(self) -> dict[str, Any]:
+        """Return basic info for the authenticated user's channel."""
+        if not self.access_token:
+            return {"connected": False, "error": "YOUTUBE_ACCESS_TOKEN not set"}
+        try:
+            r = requests.get(
+                f"{YOUTUBE_API_BASE}/channels",
+                params={"part": "snippet,statistics", "mine": "true"},
+                headers={"Authorization": f"Bearer {self.access_token}"},
+                timeout=30,
+            )
+        except requests.RequestException as exc:
+            return {"connected": False, "error": str(exc)}
+
+        if r.status_code == 401:
+            # Try a single refresh if we have a refresh token
+            refreshed = self.refresh_access_token()
+            if "access_token" in refreshed:
+                return self.get_channel_info()
+            return {"connected": False, "error": "401 Unauthorized (refresh failed)"}
+
+        if r.status_code != 200:
+            return {"connected": False, "error": f"HTTP {r.status_code}: {r.text[:200]}"}
+
+        try:
+            data = r.json()
+        except ValueError:
+            return {"connected": False, "error": "Non-JSON response"}
+
+        items = data.get("items") or []
+        if not items:
+            return {"connected": False, "error": "No channel for this account"}
+        item = items[0]
+        snippet = item.get("snippet", {})
+        stats = item.get("statistics", {})
+        return {
+            "connected": True,
+            "id": item.get("id", ""),
+            "name": snippet.get("title", ""),
+            "description": snippet.get("description", ""),
+            "thumbnail_url": (snippet.get("thumbnails") or {}).get("default", {}).get("url", ""),
+            "subscriber_count": int(stats.get("subscriberCount", 0)),
+            "video_count": int(stats.get("videoCount", 0)),
+            "view_count": int(stats.get("viewCount", 0)),
+        }
+
+    # ------------------------------------------------------------------
+    # Upload
+    # ------------------------------------------------------------------
+
+    def upload_video(
+        self,
+        video_path: str,
+        title: str,
+        description: str = "",
+        tags: list[str] | None = None,
+        category_id: str = "22",
+        privacy_status: str = "private",
+        made_for_kids: bool = False,
+    ) -> dict[str, Any]:
+        """Upload a local video file to the authenticated user's channel.
+
+        Defaults privacy_status to 'private'. The user can switch to
+        'public' or 'unlisted' from the dashboard once they have reviewed
+        the upload. This matches the project's no-silent-automation spine.
+
+        category_id 22 = "People & Blogs", a safe default for social
+        creator content. Other common values:
+          - 24: Entertainment
+          - 25: News & Politics
+          - 27: Education
+          - 28: Science & Technology
+
+        For Shorts, supply a vertical video (9:16) under 60 seconds.
+        YouTube auto-detects.
+        """
+        path = Path(video_path).expanduser().resolve()
+        if not path.exists() or not path.is_file():
+            return {"success": False, "error": f"Video file not found: {video_path}"}
+
+        if not self.access_token:
+            return {"success": False, "error": "YOUTUBE_ACCESS_TOKEN not set"}
+
+        metadata = {
+            "snippet": {
+                "title": title[:100] or "Untitled",
+                "description": description[:5000],
+                "tags": (tags or [])[:30],
+                "categoryId": category_id,
+            },
+            "status": {
+                "privacyStatus": privacy_status,
+                "selfDeclaredMadeForKids": made_for_kids,
+            },
+        }
+
+        # Multipart "related" body. Two parts: JSON metadata and the video bytes.
+        # We hand-build because requests' multipart only does form-data, not "related".
+        boundary = "----social_auto_engine_boundary"
+        body = b""
+        body += f"--{boundary}\r\n".encode()
+        body += b"Content-Type: application/json; charset=UTF-8\r\n\r\n"
+        body += json.dumps(metadata).encode("utf-8") + b"\r\n"
+        body += f"--{boundary}\r\n".encode()
+        body += b"Content-Type: video/*\r\n\r\n"
+        with path.open("rb") as fh:
+            body += fh.read()
+        body += f"\r\n--{boundary}--\r\n".encode()
+
+        headers = {
+            "Authorization": f"Bearer {self.access_token}",
+            "Content-Type": f"multipart/related; boundary={boundary}",
+            "Content-Length": str(len(body)),
+        }
+
+        try:
+            r = requests.post(
+                YOUTUBE_UPLOAD_URL,
+                params={"part": "snippet,status", "uploadType": "multipart"},
+                headers=headers,
+                data=body,
+                timeout=600,
+            )
+        except requests.RequestException as exc:
+            return {"success": False, "error": str(exc)}
+
+        if r.status_code == 401:
+            refreshed = self.refresh_access_token()
+            if "access_token" in refreshed:
+                return self.upload_video(
+                    video_path=video_path,
+                    title=title,
+                    description=description,
+                    tags=tags,
+                    category_id=category_id,
+                    privacy_status=privacy_status,
+                    made_for_kids=made_for_kids,
+                )
+
+        if r.status_code not in (200, 201):
+            return {
+                "success": False,
+                "error": f"YouTube upload HTTP {r.status_code}: {r.text[:300]}",
+            }
+
+        try:
+            data = r.json()
+        except ValueError:
+            return {"success": False, "error": f"Non-JSON response: {r.text[:200]}"}
+
+        return {
+            "success": True,
+            "id": data.get("id", ""),
+            "watch_url": f"https://www.youtube.com/watch?v={data.get('id', '')}",
+            "privacy_status": data.get("status", {}).get("privacyStatus", privacy_status),
+        }
+
+    def delete_video(self, video_id: str) -> dict[str, Any]:
+        """Delete a video by ID."""
+        if not self.access_token:
+            return {"success": False, "error": "YOUTUBE_ACCESS_TOKEN not set"}
+        try:
+            r = requests.delete(
+                f"{YOUTUBE_API_BASE}/videos",
+                params={"id": video_id},
+                headers={"Authorization": f"Bearer {self.access_token}"},
+                timeout=30,
+            )
+        except requests.RequestException as exc:
+            return {"success": False, "error": str(exc)}
+
+        if r.status_code in (200, 204):
+            return {"success": True}
+        return {"success": False, "error": f"HTTP {r.status_code}: {r.text[:200]}"}

--- a/youtube_api.py
+++ b/youtube_api.py
@@ -136,7 +136,7 @@ class YouTubeAPI:
     # Channel info
     # ------------------------------------------------------------------
 
-    def get_channel_info(self) -> dict[str, Any]:
+    def get_channel_info(self, _retried: bool = False) -> dict[str, Any]:
         """Return basic info for the authenticated user's channel."""
         if not self.access_token:
             return {"connected": False, "error": "YOUTUBE_ACCESS_TOKEN not set"}
@@ -150,11 +150,10 @@ class YouTubeAPI:
         except requests.RequestException as exc:
             return {"connected": False, "error": str(exc)}
 
-        if r.status_code == 401:
-            # Try a single refresh if we have a refresh token
+        if r.status_code == 401 and not _retried:
             refreshed = self.refresh_access_token()
             if "access_token" in refreshed:
-                return self.get_channel_info()
+                return self.get_channel_info(_retried=True)
             return {"connected": False, "error": "401 Unauthorized (refresh failed)"}
 
         if r.status_code != 200:
@@ -195,6 +194,7 @@ class YouTubeAPI:
         category_id: str = "22",
         privacy_status: str = "private",
         made_for_kids: bool = False,
+        _retried: bool = False,
     ) -> dict[str, Any]:
         """Upload a local video file to the authenticated user's channel.
 
@@ -211,10 +211,18 @@ class YouTubeAPI:
 
         For Shorts, supply a vertical video (9:16) under 60 seconds.
         YouTube auto-detects.
+
+        The _retried argument is internal: when a 401 prompts a token
+        refresh + recursive retry, the second call sets _retried=True
+        so we never recurse twice and create an infinite loop on a
+        permanently bad credential.
         """
         path = Path(video_path).expanduser().resolve()
         if not path.exists() or not path.is_file():
             return {"success": False, "error": f"Video file not found: {video_path}"}
+
+        if path.stat().st_size == 0:
+            return {"success": False, "error": "Video file is empty (0 bytes)"}
 
         if not self.access_token:
             return {"success": False, "error": "YOUTUBE_ACCESS_TOKEN not set"}
@@ -262,7 +270,7 @@ class YouTubeAPI:
         except requests.RequestException as exc:
             return {"success": False, "error": str(exc)}
 
-        if r.status_code == 401:
+        if r.status_code == 401 and not _retried:
             refreshed = self.refresh_access_token()
             if "access_token" in refreshed:
                 return self.upload_video(
@@ -273,6 +281,7 @@ class YouTubeAPI:
                     category_id=category_id,
                     privacy_status=privacy_status,
                     made_for_kids=made_for_kids,
+                    _retried=True,
                 )
 
         if r.status_code not in (200, 201):


### PR DESCRIPTION
## What

Takes the project from "four Meta adapters" to a real cross-platform publishing tool. Compose once, fan out to every selected platform, partial-failure tolerated, every post still goes through the approval queue.

## Three new adapters

- **LinkedIn** (`linkedin_api.py`) — text, image, and article posts via the UGC API. Member-tier OAuth (`openid profile email w_member_social`).
- **TikTok** (`tiktok_api.py`) — inbox-upload tier. The video lands in the user's TikTok drafts and they tap Publish in the app to finalise. Two source modes: `PULL_FROM_URL` for verified domains, chunked `FILE_UPLOAD` for local files. Direct-post tier deferred until full TikTok app review.
- **YouTube** (`youtube_api.py`) — Data API v3 video upload. Defaults `privacyStatus='private'` so the user reviews before going public. Refresh-token aware. Shorts auto-detected by aspect ratio.

## Multi-platform fan-out compose

- New `group_id` column on the `post` table. Additive migration, safe on existing databases.
- `POST /compose` accepts `platforms=facebook&platforms=linkedin&...` and creates one group with N pending rows.
- New `POST /approve-group/{group_id}` and `POST /reject-group/{group_id}`.
- Each platform's publish is tracked independently. Toast on partial failure: *"Published 3 of 4. Failed: Threads (token expired)."*

## Company-grouped UI

- Sidebar grouped by parent company: Meta (FB/IG/Threads/WhatsApp), LinkedIn, TikTok, YouTube, X. Collapsible `<details>` sections.
- Composer split into Broadcast and Direct message tabs. WhatsApp's 1:1 form stays separate (broadcast doesn't fit messaging).
- Approval queue renders broadcast posts as a single card with platform chips and Publish-all / Reject-all actions.

## OAuth callback infrastructure

- `/oauth/<platform>/start` and `/callback` for LinkedIn, TikTok, YouTube. State cookie defends against CSRF on every callback.
- `/oauth/<platform>/disconnect` clears the persisted token from `~/.social-auto-engine/tokens.env`, the live env, and the running adapter instance.
- `_store_tokens` writes to `~/.social-auto-engine/tokens.env` and patches the live adapter instances so the running dashboard sees new tokens without restart.
- Settings page has Connect / Disconnect buttons for LinkedIn / TikTok / YouTube. Other platforms show a "Set credentials in `.env`" hint.
- New `OAUTH_REDIRECT_BASE_URL` env override for reverse-proxy / tunnel deployments.

## Dashboard password authentication (opt-in)

- `dashboard/auth.py` + login templates + `AuthMiddleware`.
- Activated when `DASHBOARD_PASSWORD` env var is set, otherwise dormant.
- Cookie signed with hmac+hashlib, zero extra dependencies.

## Quality fixes

- **`_safe_page_info` no longer fakes a connected Facebook page on API failure.** The previous fallback returned a hard-coded "Hack-Tech / Education" dict that made the dashboard report Facebook as connected even when the token was missing or expired.
- **README hero updated** to honestly say five live channels (FB / IG / Threads / WA / LinkedIn) plus two code-complete adapters awaiting review (TikTok / YouTube) and one paid-tier adapter explicitly deferred (X). Roadmap table refreshed.
- **CSRF defences** on all OAuth callbacks, including LinkedIn (was missing), TikTok and YouTube (were loose).
- **YouTube infinite-recursion guard** on the 401-refresh-and-retry path.
- **TikTok 0-byte file rejection** before the chunk-count math.

## Tests and CI

- 51 tests covering db (group_id, broadcast, pending-grouped), HTTP compose flow, OAuth callbacks (start, callback rejections, disconnect), `_store_tokens`, and adapter import smoke.
- CI workflow gains a Pytest job alongside the existing lint and skills-validation jobs.

## Docs

- `docs/specs/2026-05-06-company-grouped-ui-and-multi-platform-compose-design.md` — full design spec.
- `docs/audit-2026-05-06.md` — quality-sweep-style audit, ranked findings.
- `docs/platform-tiers.md` — single source of truth for what each platform's API tiers grant, costs, and how the dashboard should surface tier capabilities. Codifies the X tier gating, TikTok inbox-vs-direct, LinkedIn member-vs-MDP, and YouTube quota stories.
- `CHANGELOG.md` — back-fills recent merged PRs and records this work under [Unreleased].

## Test plan

- [ ] `pip install -r requirements.txt` (apscheduler and sqlalchemy are now required).
- [ ] `python -m pytest tests/ -q` — 51 tests pass on a fresh database.
- [ ] `python -m dashboard.app`, hit http://127.0.0.1:7651, verify:
  - Sidebar shows Meta / LinkedIn / TikTok / YouTube / X groups.
  - Compose has Broadcast and Direct message tabs.
  - Selecting two or more platforms in Broadcast creates one group card in the inbox.
  - Single-platform legacy compose still works (regression check).
  - Settings shows all platforms with Connect / Disconnect buttons where applicable.
- [ ] Confirm `/oauth/linkedin/start` redirects to linkedin.com.
- [ ] Confirm `/oauth/tiktok/start` redirects to tiktok.com.
- [ ] Confirm `/oauth/youtube/start` redirects to google.com.
- [ ] Live test: register a LinkedIn dev app, paste keys into `.env`, click Connect, verify a real broadcast publishes to LinkedIn.

## Out of scope

- X / Twitter adapter. Deferred until paid-tier economics work. Documented in `docs/platform-tiers.md`.
- Per-platform text overrides in the composer (data model supports it, UI hook not yet rendered).
- TikTok direct-post tier (inbox-upload only for now).
- LinkedIn Marketing Developer Platform tier (member-tier only).

## Companion PR

- #16 (`docs/legal-pages`) — adds `TERMS.md` and `PRIVACY.md` so we have linkable URLs for the TikTok / LinkedIn / Meta dev-app submissions. Independent of this PR. Can land in either order.