### PR TITLE
docs: complete .env.example with TikTok, LinkedIn, YouTube sections

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,12 @@
-# Facebook / Instagram Graph API
+# =====================================================================
+#  Social Auto Engine — environment template
+#  Copy this file to .env and fill in only the platforms you use.
+#  Every section is independent. You can ship with just Meta, just
+#  LinkedIn, etc — connect more later via the Settings page.
+# =====================================================================
+
+
+# ─── Facebook + Instagram (Meta Graph API) ──────────────────────────
 # Get from https://developers.facebook.com/tools/explorer/
 # 1. Create / select your Meta App
 # 2. Switch "User or Page" to your Page
@@ -6,42 +14,90 @@
 #    pages_manage_engagement, pages_read_user_content,
 #    instagram_basic, instagram_content_publish
 # 4. Click Generate Access Token
-# 5. To make the token long-lived, run scripts/exchange_token.py with
-#    your APP_SECRET (Settings → Basic in Meta dashboard)
-
+# 5. For a long-lived token, run scripts/exchange_token.py
 FACEBOOK_PAGE_ID=
 FACEBOOK_ACCESS_TOKEN=
 
-# Optional — needed only for long-lived token exchange and webhook signing
+# Optional — needed for long-lived token exchange and webhook signing
 META_APP_ID=
 META_APP_SECRET=
 
-# Optional — port for the dashboard (default 7651)
-# DASHBOARD_PORT=7651
 
-# WhatsApp Business Cloud API
-# Get from Meta App Dashboard → WhatsApp → API Setup
-# WHATSAPP_PHONE_NUMBER_ID=
-# WHATSAPP_BUSINESS_ACCOUNT_ID=
+# ─── WhatsApp Business Cloud API ────────────────────────────────────
+# Same Meta App as above, configure under "WhatsApp → API Setup"
+WHATSAPP_PHONE_NUMBER_ID=
+WHATSAPP_BUSINESS_ACCOUNT_ID=
 
-# Threads API (Meta)
-# Get from Meta App Dashboard — uses the same app as Instagram
-# OAuth flow: visit /threads/auth in the dashboard to connect
-# THREADS_APP_ID=
-# THREADS_APP_SECRET=
-# THREADS_ACCESS_TOKEN=
-# THREADS_USER_ID=
 
-# LinkedIn (coming soon — see issue #5)
+# ─── Threads (Meta) ─────────────────────────────────────────────────
+# Same Meta App as Instagram. OAuth flow lives at /threads/auth.
+THREADS_APP_ID=
+THREADS_APP_SECRET=
+THREADS_ACCESS_TOKEN=
+THREADS_USER_ID=
+
+
+# ─── LinkedIn (member-tier publishing) ──────────────────────────────
 # Get from https://www.linkedin.com/developers/apps
-# LINKEDIN_CLIENT_ID=
-# LINKEDIN_CLIENT_SECRET=
-# LINKEDIN_ACCESS_TOKEN=
+# Required products on the app: "Sign In with LinkedIn using OpenID Connect"
+# and "Share on LinkedIn".
+# Scopes that should be approved: openid, profile, email, w_member_social.
+# Connect via /oauth/linkedin/start in the dashboard. The OAuth callback
+# writes LINKEDIN_ACCESS_TOKEN automatically into ~/.social-auto-engine/tokens.env.
+LINKEDIN_CLIENT_ID=
+LINKEDIN_CLIENT_SECRET=
+# LINKEDIN_ACCESS_TOKEN=    # set automatically by /oauth/linkedin/callback
 
-# Optional — AI providers (used by skills + future compose AI features)
+
+# ─── TikTok (inbox-upload tier) ─────────────────────────────────────
+# Get from https://developers.tiktok.com/apps
+# Required products on the app: Login Kit + Content Posting API + Display API.
+# Scopes that should be approved: user.info.basic, user.info.profile,
+# video.upload, video.list. (video.publish for direct-post — needs full review.)
+# Note: TikTok's portal labels them "Client key" (alphanumeric) and "Client secret".
+# The numeric "Client ID" is internal-only and is NOT used by the API.
+# Connect via /oauth/tiktok/start in the dashboard.
+TIKTOK_CLIENT_KEY=
+TIKTOK_CLIENT_SECRET=
+# TIKTOK_ACCESS_TOKEN=     # set automatically by /oauth/tiktok/callback
+# TIKTOK_REFRESH_TOKEN=    # set automatically by /oauth/tiktok/callback
+
+
+# ─── YouTube (Data API v3) ──────────────────────────────────────────
+# Get from https://console.cloud.google.com/apis/credentials
+# Create OAuth 2.0 client ID, application type "Web application".
+# Add authorised redirect URI: http://localhost:7652/oauth/youtube/callback
+# Enable "YouTube Data API v3" under APIs & Services.
+# Scopes used: youtube.upload, youtube.readonly.
+# Quota: 100 units per upload, 10,000 units/day default = ~100 uploads/day.
+# Connect via /oauth/youtube/start in the dashboard.
+YOUTUBE_CLIENT_ID=
+YOUTUBE_CLIENT_SECRET=
+# YOUTUBE_ACCESS_TOKEN=    # set automatically by /oauth/youtube/callback
+# YOUTUBE_REFRESH_TOKEN=   # set automatically by /oauth/youtube/callback
+
+
+# ─── Dashboard (optional) ───────────────────────────────────────────
+# Set DASHBOARD_PASSWORD to enable the cookie-based login.
+# Leave it unset and the dashboard runs with no auth (localhost-only use).
+# DASHBOARD_PASSWORD=
+# DASHBOARD_SECRET_KEY=        # 64+ random hex chars; auto-generated if absent
+# DASHBOARD_PORT=7651          # default; change if 7651 is taken
+
+# Override OAuth callback base URL when running behind a tunnel/proxy.
+# Default behaviour uses the request's host, which works for localhost.
+# Example: OAUTH_REDIRECT_BASE_URL=https://yourdomain.com
+# OAUTH_REDIRECT_BASE_URL=
+
+
+# ─── AI providers (optional) ────────────────────────────────────────
+# Used by the AI compose feature and by skills under skills/. Pick whichever
+# you have. The dashboard works fine with none of these set.
 # OPENAI_API_KEY=
-# GOOGLE_AI_API_KEY=
 # ANTHROPIC_API_KEY=
+# GOOGLE_AI_API_KEY=
+# XAI_GROK_API_KEY=     # Grok via api.x.ai (LLM only, NOT the X social API)
 
-# Optional — research / scraping
+
+# ─── Research / scraping (optional) ─────────────────────────────────
 # APIFY_API_TOKEN=


### PR DESCRIPTION
## What

Fills the gap left by #17. The multi-platform PR added three new adapters but I forgot to update `.env.example`. This PR brings the template up to date so anyone cloning the repo has the complete picture.

## Sections added

- **LinkedIn** — `LINKEDIN_CLIENT_ID`, `LINKEDIN_CLIENT_SECRET`, plus a note that `LINKEDIN_ACCESS_TOKEN` is set automatically by the OAuth callback.
- **TikTok** — `TIKTOK_CLIENT_KEY`, `TIKTOK_CLIENT_SECRET`, plus a clarifying note that the numeric "Client ID" shown in the TikTok dev portal is internal-only and is NOT used by the API. (We hit this exact confusion live during testing.)
- **YouTube** — `YOUTUBE_CLIENT_ID`, `YOUTUBE_CLIENT_SECRET`, plus the Google Cloud Console setup steps and the redirect URI to register.
- **Dashboard** — `DASHBOARD_PASSWORD`, `DASHBOARD_SECRET_KEY`, `DASHBOARD_PORT`, and the new `OAUTH_REDIRECT_BASE_URL` override for reverse-proxy / tunnel deployments.
- **AI providers** — OpenAI, Anthropic, Google, and an `XAI_GROK_API_KEY` entry with a note that this is Grok-as-LLM via api.x.ai, NOT the X social-network API. (Caught a real misconception during the live test session.)

## Test plan

- [ ] `cp .env.example .env` produces a usable template with no syntax errors.
- [ ] Each section is independent — a fresh user can ship with just Meta or just LinkedIn without setting irrelevant vars.

This is a pure docs/template change, no code touched, no behaviour change.