### PR TITLE
feat: add Facebook token refresh helper

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,6 +27,18 @@ To run the MCP server (for Claude Desktop / Cursor / any MCP client):
 python server.py
 ```
 
+### Refreshing the Facebook Page token
+
+Graph API Explorer hands out short-lived user tokens that expire in about an hour. When the dashboard starts returning 401s on Facebook calls, paste a fresh user token from [Graph API Explorer](https://developers.facebook.com/tools/explorer/) and run:
+
+```bash
+python -m scripts.refresh_token <SHORT_LIVED_USER_TOKEN>
+```
+
+This requires `META_APP_ID`, `META_APP_SECRET`, and `FACEBOOK_PAGE_ID` in `.env`. The script exchanges the short-lived user token for a long-lived (60-day) one, derives the never-expiring Page access token via `/me/accounts`, and writes it back to `.env` as `FACEBOOK_ACCESS_TOKEN`. Restart the dashboard and you are back online.
+
+The same logic is exposed as `Manager.refresh_facebook_token(short_lived_user_token)` for use from the dashboard on a 401 response.
+
 ## Project structure
 
 ```

--- a/manager.py
+++ b/manager.py
@@ -1,4 +1,7 @@
+import os
+from pathlib import Path
 from typing import Any
+
 from facebook_api import FacebookAPI
 from instagram_api import InstagramAPI
 from whatsapp_api import WhatsAppAPI
@@ -17,6 +20,46 @@ class Manager:
         self.linkedin = LinkedInAPI()
         self.tiktok = TikTokAPI()
         self.youtube = YouTubeAPI()
+
+    def refresh_facebook_token(self, short_lived_user_token: str) -> str:
+        """Refresh the Facebook Page access token from a short-lived user token.
+
+        Reads `META_APP_ID`, `META_APP_SECRET`, and `FACEBOOK_PAGE_ID` from
+        the environment. Exchanges `short_lived_user_token` for a long-lived
+        user token, derives the Page access token via `/me/accounts`, writes
+        the new token back to `.env`, and returns it.
+
+        The dashboard can call this on a 401 response by surfacing a form
+        that asks the user to paste a fresh Graph API Explorer token.
+        """
+        from scripts.refresh_token import (
+            TokenRefreshError,
+            refresh_page_token,
+            write_token_to_env,
+        )
+
+        app_id = os.environ.get("META_APP_ID")
+        app_secret = os.environ.get("META_APP_SECRET")
+        page_id = os.environ.get("FACEBOOK_PAGE_ID")
+        missing = [
+            name
+            for name, value in (
+                ("META_APP_ID", app_id),
+                ("META_APP_SECRET", app_secret),
+                ("FACEBOOK_PAGE_ID", page_id),
+            )
+            if not value
+        ]
+        if missing:
+            raise TokenRefreshError(
+                f"Missing required env vars: {', '.join(missing)}"
+            )
+
+        page_token = refresh_page_token(
+            short_lived_user_token, app_id, app_secret, page_id
+        )
+        write_token_to_env(Path.cwd() / ".env", page_token)
+        return page_token
 
     def post_to_facebook(self, message: str) -> dict[str, Any]:
         return self.api.post_message(message)

--- a/scripts/refresh_token.py
+++ b/scripts/refresh_token.py
@@ -1,0 +1,197 @@
+"""Refresh the Facebook Page access token in `.env`.
+
+Graph API Explorer hands out short-lived user tokens that expire in about
+an hour. Once the user provides `META_APP_ID` and `META_APP_SECRET` in
+their `.env`, this script exchanges any short-lived user token for a
+long-lived (60-day) user token, then derives the never-expiring Page
+access token from `/me/accounts` and writes it back to `.env`.
+
+CLI:
+
+    python -m scripts.refresh_token <SHORT_LIVED_USER_TOKEN>
+
+After this completes the dashboard works again without further input.
+The same exchange logic is exposed as `Manager.refresh_facebook_token`
+so the dashboard can offer a "refresh token" form on a 401 response.
+"""
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+import requests
+from dotenv import load_dotenv
+
+
+GRAPH_API_VERSION = "v22.0"
+GRAPH_API_BASE = f"https://graph.facebook.com/{GRAPH_API_VERSION}"
+
+
+class TokenRefreshError(RuntimeError):
+    """Raised when the Meta Graph API returns an error during token refresh."""
+
+
+def exchange_short_lived_for_long_lived(
+    short_lived_token: str,
+    app_id: str,
+    app_secret: str,
+) -> str:
+    """Exchange a short-lived user token for a long-lived (60-day) one.
+
+    Returns the new user access token. Raises `TokenRefreshError` if the
+    exchange call fails or the response does not include a token.
+    """
+    response = requests.get(
+        f"{GRAPH_API_BASE}/oauth/access_token",
+        params={
+            "grant_type": "fb_exchange_token",
+            "client_id": app_id,
+            "client_secret": app_secret,
+            "fb_exchange_token": short_lived_token,
+        },
+        timeout=15,
+    )
+    payload = response.json()
+    if "error" in payload:
+        raise TokenRefreshError(
+            f"Token exchange failed: {payload['error'].get('message', payload['error'])}"
+        )
+    if "access_token" not in payload:
+        raise TokenRefreshError(
+            f"Token exchange returned no access_token: {payload}"
+        )
+    return payload["access_token"]
+
+
+def fetch_page_token(long_lived_user_token: str, page_id: str) -> str:
+    """Fetch the never-expiring Page access token for `page_id`.
+
+    Calls `/me/accounts` with the long-lived user token and returns the
+    Page token whose entry matches `page_id`. Raises `TokenRefreshError`
+    if the API errors or the page is not in the returned list.
+    """
+    response = requests.get(
+        f"{GRAPH_API_BASE}/me/accounts",
+        params={"access_token": long_lived_user_token},
+        timeout=15,
+    )
+    payload = response.json()
+    if "error" in payload:
+        raise TokenRefreshError(
+            f"/me/accounts failed: {payload['error'].get('message', payload['error'])}"
+        )
+    pages = payload.get("data", [])
+    for page in pages:
+        if str(page.get("id")) == str(page_id):
+            token = page.get("access_token")
+            if not token:
+                raise TokenRefreshError(
+                    f"Page {page_id} entry has no access_token field"
+                )
+            return token
+    available = [str(p.get("id")) for p in pages]
+    raise TokenRefreshError(
+        f"Page {page_id} not found in /me/accounts. Available pages: {available}"
+    )
+
+
+def refresh_page_token(
+    short_lived_token: str,
+    app_id: str,
+    app_secret: str,
+    page_id: str,
+) -> str:
+    """Run the full short-lived to Page token refresh in one call."""
+    long_lived = exchange_short_lived_for_long_lived(
+        short_lived_token, app_id, app_secret
+    )
+    return fetch_page_token(long_lived, page_id)
+
+
+def write_token_to_env(env_path: Path, page_token: str) -> None:
+    """Replace `FACEBOOK_ACCESS_TOKEN` in `.env`, or append it if absent.
+
+    Preserves all other lines (comments, other variables) untouched.
+    Creates the file if it does not exist.
+    """
+    line = f"FACEBOOK_ACCESS_TOKEN={page_token}\n"
+    if not env_path.exists():
+        env_path.write_text(line, encoding="utf-8")
+        return
+
+    existing_lines = env_path.read_text(encoding="utf-8").splitlines(keepends=True)
+    replaced = False
+    new_lines: list[str] = []
+    for raw in existing_lines:
+        stripped = raw.lstrip()
+        if stripped.startswith("FACEBOOK_ACCESS_TOKEN="):
+            new_lines.append(line)
+            replaced = True
+        else:
+            new_lines.append(raw)
+    if not replaced:
+        if new_lines and not new_lines[-1].endswith("\n"):
+            new_lines[-1] = new_lines[-1] + "\n"
+        new_lines.append(line)
+    env_path.write_text("".join(new_lines), encoding="utf-8")
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point. Returns a Unix-style exit code."""
+    args = sys.argv[1:] if argv is None else argv
+    usage = (
+        "Usage: python -m scripts.refresh_token <SHORT_LIVED_USER_TOKEN>\n"
+        "\n"
+        "Reads META_APP_ID, META_APP_SECRET, and FACEBOOK_PAGE_ID from\n"
+        ".env, exchanges the short-lived user token for a long-lived\n"
+        "Page access token, then writes the result back to .env as\n"
+        "FACEBOOK_ACCESS_TOKEN."
+    )
+    if not args or args[0] in {"-h", "--help"}:
+        print(usage)
+        return 0
+    if len(args) != 1:
+        print(usage)
+        return 1
+
+    load_dotenv()
+    app_id = os.environ.get("META_APP_ID")
+    app_secret = os.environ.get("META_APP_SECRET")
+    page_id = os.environ.get("FACEBOOK_PAGE_ID")
+    missing = [
+        name
+        for name, value in (
+            ("META_APP_ID", app_id),
+            ("META_APP_SECRET", app_secret),
+            ("FACEBOOK_PAGE_ID", page_id),
+        )
+        if not value
+    ]
+    if missing:
+        print(f"Missing required env vars: {', '.join(missing)}", file=sys.stderr)
+        print(
+            "Add them to .env. See .env.example for the Facebook section.",
+            file=sys.stderr,
+        )
+        return 2
+
+    try:
+        page_token = refresh_page_token(args[0], app_id, app_secret, page_id)
+    except TokenRefreshError as exc:
+        print(f"Refresh failed: {exc}", file=sys.stderr)
+        return 3
+
+    env_path = Path.cwd() / ".env"
+    write_token_to_env(env_path, page_token)
+    print(f"Wrote refreshed FACEBOOK_ACCESS_TOKEN to {env_path}")
+    return 0
+
+
+def _entry_point() -> None:
+    raise SystemExit(main())
+
+
+if __name__ == "__main__":
+    _entry_point()

--- a/tests/test_refresh_token.py
+++ b/tests/test_refresh_token.py
@@ -1,0 +1,239 @@
+"""Tests for the Facebook token refresh helper.
+
+All HTTP calls are mocked so the tests never reach Meta's real API.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from scripts.refresh_token import (
+    TokenRefreshError,
+    exchange_short_lived_for_long_lived,
+    fetch_page_token,
+    main,
+    refresh_page_token,
+    write_token_to_env,
+)
+
+
+class _MockResponse:
+    def __init__(self, payload: dict):
+        self._payload = payload
+
+    def json(self) -> dict:
+        return self._payload
+
+
+def test_exchange_returns_long_lived_token():
+    with patch("scripts.refresh_token.requests.get") as mock_get:
+        mock_get.return_value = _MockResponse(
+            {"access_token": "LONG_LIVED_USER_TOKEN", "token_type": "bearer"}
+        )
+        token = exchange_short_lived_for_long_lived("SHORT", "APP_ID", "APP_SECRET")
+        assert token == "LONG_LIVED_USER_TOKEN"
+
+
+def test_exchange_raises_on_meta_error_payload():
+    with patch("scripts.refresh_token.requests.get") as mock_get:
+        mock_get.return_value = _MockResponse(
+            {"error": {"message": "Invalid OAuth access token", "code": 190}}
+        )
+        with pytest.raises(TokenRefreshError, match="Invalid OAuth"):
+            exchange_short_lived_for_long_lived("BAD", "APP_ID", "APP_SECRET")
+
+
+def test_exchange_raises_on_missing_access_token_key():
+    with patch("scripts.refresh_token.requests.get") as mock_get:
+        mock_get.return_value = _MockResponse({"unexpected": "shape"})
+        with pytest.raises(TokenRefreshError, match="no access_token"):
+            exchange_short_lived_for_long_lived("SHORT", "APP_ID", "APP_SECRET")
+
+
+def test_fetch_page_token_finds_matching_page():
+    with patch("scripts.refresh_token.requests.get") as mock_get:
+        mock_get.return_value = _MockResponse(
+            {
+                "data": [
+                    {"id": "111", "access_token": "PAGE_TOKEN_OTHER"},
+                    {"id": "999", "access_token": "PAGE_TOKEN_TARGET"},
+                ]
+            }
+        )
+        token = fetch_page_token("LONG_LIVED", "999")
+        assert token == "PAGE_TOKEN_TARGET"
+
+
+def test_fetch_page_token_raises_when_page_not_in_list():
+    with patch("scripts.refresh_token.requests.get") as mock_get:
+        mock_get.return_value = _MockResponse(
+            {"data": [{"id": "111", "access_token": "OTHER"}]}
+        )
+        with pytest.raises(TokenRefreshError, match="not found"):
+            fetch_page_token("LONG_LIVED", "999")
+
+
+def test_fetch_page_token_raises_on_meta_error():
+    with patch("scripts.refresh_token.requests.get") as mock_get:
+        mock_get.return_value = _MockResponse(
+            {"error": {"message": "Token expired"}}
+        )
+        with pytest.raises(TokenRefreshError, match="/me/accounts failed"):
+            fetch_page_token("EXPIRED", "999")
+
+
+def test_refresh_page_token_chains_exchange_then_fetch():
+    with patch("scripts.refresh_token.requests.get") as mock_get:
+        mock_get.side_effect = [
+            _MockResponse({"access_token": "LONG_LIVED"}),
+            _MockResponse({"data": [{"id": "999", "access_token": "PAGE_TOKEN"}]}),
+        ]
+        token = refresh_page_token("SHORT", "APP_ID", "APP_SECRET", "999")
+        assert token == "PAGE_TOKEN"
+        assert mock_get.call_count == 2
+
+
+def test_write_token_creates_env_when_missing(tmp_path: Path):
+    env_path = tmp_path / ".env"
+    write_token_to_env(env_path, "NEW_TOKEN")
+    assert env_path.read_text(encoding="utf-8") == "FACEBOOK_ACCESS_TOKEN=NEW_TOKEN\n"
+
+
+def test_write_token_replaces_existing_facebook_access_token(tmp_path: Path):
+    env_path = tmp_path / ".env"
+    env_path.write_text(
+        "FACEBOOK_PAGE_ID=12345\n"
+        "FACEBOOK_ACCESS_TOKEN=OLD_TOKEN\n"
+        "OPENAI_API_KEY=sk-test\n",
+        encoding="utf-8",
+    )
+    write_token_to_env(env_path, "NEW_TOKEN")
+    contents = env_path.read_text(encoding="utf-8")
+    assert "FACEBOOK_ACCESS_TOKEN=NEW_TOKEN" in contents
+    assert "FACEBOOK_ACCESS_TOKEN=OLD_TOKEN" not in contents
+    assert "FACEBOOK_PAGE_ID=12345" in contents
+    assert "OPENAI_API_KEY=sk-test" in contents
+
+
+def test_write_token_appends_when_facebook_access_token_missing(tmp_path: Path):
+    env_path = tmp_path / ".env"
+    env_path.write_text("FACEBOOK_PAGE_ID=12345\n", encoding="utf-8")
+    write_token_to_env(env_path, "FRESH_TOKEN")
+    contents = env_path.read_text(encoding="utf-8")
+    assert contents.startswith("FACEBOOK_PAGE_ID=12345\n")
+    assert contents.endswith("FACEBOOK_ACCESS_TOKEN=FRESH_TOKEN\n")
+
+
+def test_write_token_appends_newline_when_existing_file_has_no_trailing_newline(tmp_path: Path):
+    env_path = tmp_path / ".env"
+    env_path.write_text("FACEBOOK_PAGE_ID=12345", encoding="utf-8")
+    write_token_to_env(env_path, "FRESH_TOKEN")
+    contents = env_path.read_text(encoding="utf-8")
+    assert contents == "FACEBOOK_PAGE_ID=12345\nFACEBOOK_ACCESS_TOKEN=FRESH_TOKEN\n"
+
+
+def test_main_with_no_args_prints_help_and_exits_zero(capsys):
+    rc = main([])
+    captured = capsys.readouterr()
+    assert rc == 0
+    assert "Usage:" in captured.out
+
+
+def test_main_with_help_flag_prints_help(capsys):
+    rc = main(["--help"])
+    captured = capsys.readouterr()
+    assert rc == 0
+    assert "Usage:" in captured.out
+
+
+def test_main_with_too_many_args_prints_help_and_exits_nonzero(capsys):
+    rc = main(["TOKEN_A", "TOKEN_B"])
+    captured = capsys.readouterr()
+    assert rc != 0
+    assert "Usage:" in captured.out
+
+
+def test_main_exits_with_code_2_when_required_env_vars_missing(monkeypatch, capsys):
+    monkeypatch.delenv("META_APP_ID", raising=False)
+    monkeypatch.delenv("META_APP_SECRET", raising=False)
+    monkeypatch.delenv("FACEBOOK_PAGE_ID", raising=False)
+    with patch("scripts.refresh_token.load_dotenv"):
+        rc = main(["SHORT_LIVED"])
+    captured = capsys.readouterr()
+    assert rc == 2
+    assert "Missing required env vars" in captured.err
+
+
+def test_main_exits_with_code_3_on_token_refresh_error(monkeypatch, capsys, tmp_path):
+    monkeypatch.setenv("META_APP_ID", "APP_ID")
+    monkeypatch.setenv("META_APP_SECRET", "APP_SECRET")
+    monkeypatch.setenv("FACEBOOK_PAGE_ID", "999")
+    monkeypatch.chdir(tmp_path)
+    with (
+        patch("scripts.refresh_token.load_dotenv"),
+        patch("scripts.refresh_token.requests.get") as mock_get,
+    ):
+        mock_get.return_value = _MockResponse(
+            {"error": {"message": "Invalid OAuth access token"}}
+        )
+        rc = main(["BAD_TOKEN"])
+    captured = capsys.readouterr()
+    assert rc == 3
+    assert "Refresh failed" in captured.err
+
+
+def test_main_writes_token_and_exits_zero_on_success(monkeypatch, capsys, tmp_path):
+    monkeypatch.setenv("META_APP_ID", "APP_ID")
+    monkeypatch.setenv("META_APP_SECRET", "APP_SECRET")
+    monkeypatch.setenv("FACEBOOK_PAGE_ID", "999")
+    monkeypatch.chdir(tmp_path)
+    with (
+        patch("scripts.refresh_token.load_dotenv"),
+        patch("scripts.refresh_token.requests.get") as mock_get,
+    ):
+        mock_get.side_effect = [
+            _MockResponse({"access_token": "LONG_LIVED"}),
+            _MockResponse({"data": [{"id": "999", "access_token": "PAGE_TOKEN"}]}),
+        ]
+        rc = main(["SHORT_LIVED"])
+    captured = capsys.readouterr()
+    assert rc == 0
+    env_contents = (tmp_path / ".env").read_text(encoding="utf-8")
+    assert env_contents == "FACEBOOK_ACCESS_TOKEN=PAGE_TOKEN\n"
+    assert "Wrote refreshed FACEBOOK_ACCESS_TOKEN" in captured.out
+
+
+def test_manager_refresh_facebook_token_calls_through(monkeypatch, tmp_path):
+    monkeypatch.setenv("META_APP_ID", "APP_ID")
+    monkeypatch.setenv("META_APP_SECRET", "APP_SECRET")
+    monkeypatch.setenv("FACEBOOK_PAGE_ID", "999")
+    monkeypatch.chdir(tmp_path)
+
+    from manager import Manager
+
+    mgr = Manager()
+    with patch("scripts.refresh_token.requests.get") as mock_get:
+        mock_get.side_effect = [
+            _MockResponse({"access_token": "LONG_LIVED"}),
+            _MockResponse({"data": [{"id": "999", "access_token": "PAGE_TOKEN"}]}),
+        ]
+        token = mgr.refresh_facebook_token("SHORT_LIVED")
+
+    assert token == "PAGE_TOKEN"
+    assert (tmp_path / ".env").read_text(encoding="utf-8") == (
+        "FACEBOOK_ACCESS_TOKEN=PAGE_TOKEN\n"
+    )
+
+
+def test_manager_refresh_facebook_token_raises_when_env_missing(monkeypatch):
+    monkeypatch.delenv("META_APP_ID", raising=False)
+    monkeypatch.delenv("META_APP_SECRET", raising=False)
+    monkeypatch.delenv("FACEBOOK_PAGE_ID", raising=False)
+
+    from manager import Manager
+
+    mgr = Manager()
+    with pytest.raises(TokenRefreshError, match="Missing required env vars"):
+        mgr.refresh_facebook_token("SHORT_LIVED")


### PR DESCRIPTION
## What this changes

Adds `scripts/refresh_token.py`: a CLI plus reusable module functions that turn a short-lived Facebook user token (the kind Graph API Explorer hands out, expires in about an hour) into the never-expiring Page access token used by the dashboard.

Flow:

1. Exchange short-lived user token for a long-lived (60-day) one via `oauth/access_token?grant_type=fb_exchange_token`.
2. Call `/me/accounts` with the long-lived user token, locate the entry for `FACEBOOK_PAGE_ID`, take its `access_token` (the long-lived Page token).
3. Write the result back to `.env` as `FACEBOOK_ACCESS_TOKEN`, replacing in place if the key exists or appending otherwise.

`Manager.refresh_facebook_token(short_lived_user_token)` exposes the same flow so the dashboard can put up a "paste a fresh token" form on a 401 response, exactly as the issue asked.

## Why

Closes #2. Right now FB tokens silently expire in about an hour and the dashboard breaks every time the user comes back. There is no in-product recovery path. This closes that silent-failure loop and matches the project's "no silent automation" spine.

## Approval-queue safety check

- [x] This change does not add a new write action

## Verification

- [x] 19 new pytest tests in `tests/test_refresh_token.py`. All `requests.get` calls are mocked. No real Meta API contact.
- [x] Tests cover: exchange happy path, two error-payload shapes, `/me/accounts` page lookup (found / missing / errored), `.env` write (create / replace / append / trailing-newline edge case), CLI exit codes 0 / 1 / 2 / 3, and the `Manager.refresh_facebook_token` passthrough.
- [x] Full suite: `pytest tests/` runs 81 tests, all green, in ~21s on Python 3.13.
- [x] Manual smoke: `python -m scripts.refresh_token --help` prints usage and exits 0; `python -m scripts.refresh_token` (no args) prints usage and exits 0; bogus token call returns exit 3 with the API error.
- [x] Documented in `CONTRIBUTING.md` under "Refreshing the Facebook Page token".

## Screenshots / recording

n/a, no UI change. The dashboard-side form on 401 is a follow-up.