### PR TITLE
feat: add AI compose backend (provider abstraction + /generate)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -98,6 +98,10 @@ YOUTUBE_CLIENT_SECRET=
 # GOOGLE_AI_API_KEY=
 # XAI_GROK_API_KEY=     # Grok via api.x.ai (LLM only, NOT the X social API)
 
+# Default provider for the dashboard's AI compose (Sparkles button).
+# Valid values: claude, openai, gemini. Falls back to claude when unset.
+# AI_PROVIDER=claude
+
 
 # ─── Research / scraping (optional) ─────────────────────────────────
 # APIFY_API_TOKEN=

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,6 +39,16 @@ This requires `META_APP_ID`, `META_APP_SECRET`, and `FACEBOOK_PAGE_ID` in `.env`
 
 The same logic is exposed as `Manager.refresh_facebook_token(short_lived_user_token)` for use from the dashboard on a 401 response.
 
+### Wiring an AI provider for the compose Sparkles button
+
+The `POST /generate` endpoint (and `content.generator.generate_post`) routes to one of three providers, picked by `AI_PROVIDER` in `.env`:
+
+- `claude` (default). Needs `ANTHROPIC_API_KEY` and `pip install anthropic`.
+- `openai`. Needs `OPENAI_API_KEY` and `pip install openai`.
+- `gemini`. Needs `GOOGLE_AI_API_KEY` and `pip install google-generativeai`.
+
+Only the SDK for your chosen provider needs to be installed. Voice tuning is automatic. If `about-me.md` or `voice.md` exist at the project root they get prepended to every prompt as the voice profile.
+
 ## Project structure
 
 ```

--- a/content/generator.py
+++ b/content/generator.py
@@ -1,0 +1,152 @@
+"""Generate post drafts via Claude, OpenAI, or Gemini.
+
+The compose dashboard's Sparkles button hits `POST /generate`, which calls
+`generate_post(topic)`. The provider is chosen by the `AI_PROVIDER`
+environment variable (`claude`, `openai`, or `gemini`). Default is
+`claude`.
+
+The voice profile, if present, is read from `about-me.md` and `voice.md`
+at the project root and prepended to the prompt. If neither file exists
+the generator falls back to a topic-only prompt.
+
+Provider SDKs are imported lazily so users only need to install the one
+they actually use.
+"""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Callable
+
+
+CLAUDE_MODEL = "claude-sonnet-4-6"
+OPENAI_MODEL = "gpt-4o-mini"
+GEMINI_MODEL = "gemini-1.5-flash"
+MAX_OUTPUT_TOKENS = 400
+
+
+class GeneratorError(RuntimeError):
+    """Raised when post generation fails."""
+
+
+def _read_voice_profile(root: Path) -> str:
+    """Return the concatenated contents of `about-me.md` and `voice.md`.
+
+    Either or both may be absent. Missing files contribute nothing. The
+    return value is stripped of trailing whitespace.
+    """
+    parts: list[str] = []
+    for filename in ("about-me.md", "voice.md"):
+        candidate = root / filename
+        if candidate.is_file():
+            parts.append(candidate.read_text(encoding="utf-8"))
+    return "\n\n".join(parts).strip()
+
+
+def _build_prompt(topic: str, voice_profile: str) -> str:
+    """Compose the user prompt for the chosen provider.
+
+    The prompt asks for a short on-brand social post and instructs the
+    model to return only the post text. The voice profile is prepended
+    when non-empty.
+    """
+    sections = ["Draft a short, on-brand social media post."]
+    if voice_profile:
+        sections.append(f"Voice profile:\n{voice_profile}")
+    sections.append(f"Topic: {topic}")
+    sections.append(
+        "Return only the post text. No headlines and no hashtags unless they "
+        "are clearly natural to the voice profile above."
+    )
+    return "\n\n".join(sections)
+
+
+def _generate_claude(prompt: str) -> str:
+    import anthropic  # late import: only required when the user picks claude
+
+    client = anthropic.Anthropic()
+    response = client.messages.create(
+        model=CLAUDE_MODEL,
+        max_tokens=MAX_OUTPUT_TOKENS,
+        messages=[{"role": "user", "content": prompt}],
+    )
+    return response.content[0].text.strip()
+
+
+def _generate_openai(prompt: str) -> str:
+    from openai import OpenAI  # late import
+
+    client = OpenAI()
+    response = client.chat.completions.create(
+        model=OPENAI_MODEL,
+        max_tokens=MAX_OUTPUT_TOKENS,
+        messages=[{"role": "user", "content": prompt}],
+    )
+    return response.choices[0].message.content.strip()
+
+
+def _generate_gemini(prompt: str) -> str:
+    import google.generativeai as genai  # late import
+
+    api_key = os.environ.get("GOOGLE_AI_API_KEY")
+    if not api_key:
+        raise GeneratorError("GOOGLE_AI_API_KEY is not set in the environment")
+    genai.configure(api_key=api_key)
+    model = genai.GenerativeModel(GEMINI_MODEL)
+    response = model.generate_content(prompt)
+    return response.text.strip()
+
+
+_PROVIDERS: dict[str, Callable[[str], str]] = {
+    "claude": _generate_claude,
+    "openai": _generate_openai,
+    "gemini": _generate_gemini,
+}
+
+
+def generate_post(
+    topic: str,
+    voice_profile: str | None = None,
+    provider: str | None = None,
+    project_root: Path | None = None,
+) -> str:
+    """Generate a post draft.
+
+    `topic` is the user-supplied subject line ("What's this post about?").
+    `voice_profile` overrides the file-based load when not None, including
+    when set to an empty string (which suppresses the voice section).
+    `provider` overrides the `AI_PROVIDER` environment variable.
+    `project_root` overrides the directory used to look for `voice.md`
+    and `about-me.md` (defaults to `Path.cwd()`).
+
+    Raises `GeneratorError` on empty topic, unknown provider, missing SDK,
+    or any provider call failure.
+    """
+    topic = topic.strip()
+    if not topic:
+        raise GeneratorError("topic must not be empty")
+
+    chosen = (provider or os.environ.get("AI_PROVIDER") or "claude").lower()
+    if chosen not in _PROVIDERS:
+        valid = ", ".join(sorted(_PROVIDERS))
+        raise GeneratorError(
+            f"Unknown AI provider '{chosen}'. Valid options: {valid}."
+        )
+
+    if voice_profile is None:
+        root = project_root or Path.cwd()
+        voice_profile = _read_voice_profile(root)
+
+    prompt = _build_prompt(topic, voice_profile)
+    handler = _PROVIDERS[chosen]
+    try:
+        return handler(prompt)
+    except ImportError as exc:
+        raise GeneratorError(
+            f"The '{chosen}' provider needs its SDK installed. "
+            f"Try: pip install {chosen}"
+        ) from exc
+    except GeneratorError:
+        raise
+    except Exception as exc:
+        raise GeneratorError(f"{chosen} generation failed: {exc}") from exc

--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -371,6 +371,26 @@ async def compose(
     return _refresh_all(request)
 
 
+@app.post("/generate", response_class=HTMLResponse)
+async def generate(request: Request, topic: str = Form("")):
+    """Generate a post draft via the configured AI provider.
+
+    The Sparkles button on the compose form posts a topic here and
+    receives the generated post text in the response body. The client
+    drops it into the textarea so the user can edit before submitting.
+    """
+    from content.generator import GeneratorError, generate_post
+
+    topic = topic.strip()
+    if not topic:
+        raise HTTPException(400, "Topic must not be empty.")
+    try:
+        text = generate_post(topic, project_root=ROOT)
+    except GeneratorError as exc:
+        raise HTTPException(500, str(exc))
+    return HTMLResponse(text)
+
+
 @app.post("/approve/{post_id}", response_class=HTMLResponse)
 async def approve(request: Request, post_id: int):
     post = db.get_post(post_id)

--- a/tests/test_generate_route.py
+++ b/tests/test_generate_route.py
@@ -1,0 +1,54 @@
+"""HTTP-level tests for the dashboard's POST /generate endpoint.
+
+The actual provider call is mocked so the tests run without anthropic,
+openai, or google-generativeai installed.
+"""
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from fastapi.testclient import TestClient
+
+from dashboard import app as dash_app
+
+
+def test_generate_returns_200_and_text_for_valid_topic():
+    client = TestClient(dash_app.app)
+    with patch("content.generator.generate_post", return_value="DRAFTED POST TEXT"):
+        response = client.post("/generate", data={"topic": "Sourdough rise tips"})
+    assert response.status_code == 200
+    assert response.text == "DRAFTED POST TEXT"
+
+
+def test_generate_returns_400_for_empty_topic():
+    client = TestClient(dash_app.app)
+    response = client.post("/generate", data={"topic": ""})
+    assert response.status_code == 400
+
+
+def test_generate_returns_400_for_whitespace_topic():
+    client = TestClient(dash_app.app)
+    response = client.post("/generate", data={"topic": "   \n  "})
+    assert response.status_code == 400
+
+
+def test_generate_returns_500_when_generator_raises():
+    from content.generator import GeneratorError
+
+    client = TestClient(dash_app.app)
+    with patch(
+        "content.generator.generate_post",
+        side_effect=GeneratorError("upstream rejected the prompt"),
+    ):
+        response = client.post("/generate", data={"topic": "Sourdough"})
+    assert response.status_code == 500
+    assert "upstream rejected" in response.text
+
+
+def test_generate_strips_whitespace_around_topic_before_calling_generator():
+    client = TestClient(dash_app.app)
+    with patch("content.generator.generate_post", return_value="ok") as mock_gen:
+        response = client.post("/generate", data={"topic": "  Sourdough  \n"})
+    assert response.status_code == 200
+    args, kwargs = mock_gen.call_args
+    assert args[0] == "Sourdough"

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -1,0 +1,192 @@
+"""Tests for content.generator.
+
+Provider-specific helpers are not exercised against real SDKs. We mock
+the entries in `_PROVIDERS` so the tests run without anthropic, openai,
+or google-generativeai installed.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from content.generator import (
+    GeneratorError,
+    _build_prompt,
+    _read_voice_profile,
+    generate_post,
+)
+
+
+def test_read_voice_profile_returns_empty_when_no_files(tmp_path: Path):
+    assert _read_voice_profile(tmp_path) == ""
+
+
+def test_read_voice_profile_reads_about_me_only(tmp_path: Path):
+    (tmp_path / "about-me.md").write_text("I am a baker in Lisbon.", encoding="utf-8")
+    assert _read_voice_profile(tmp_path) == "I am a baker in Lisbon."
+
+
+def test_read_voice_profile_reads_voice_only(tmp_path: Path):
+    (tmp_path / "voice.md").write_text("Wry, short sentences.", encoding="utf-8")
+    assert _read_voice_profile(tmp_path) == "Wry, short sentences."
+
+
+def test_read_voice_profile_concatenates_both_files_in_order(tmp_path: Path):
+    (tmp_path / "about-me.md").write_text("Baker.", encoding="utf-8")
+    (tmp_path / "voice.md").write_text("Wry.", encoding="utf-8")
+    result = _read_voice_profile(tmp_path)
+    assert result == "Baker.\n\nWry."
+
+
+def test_build_prompt_omits_voice_section_when_profile_empty():
+    prompt = _build_prompt("Sourdough rise tips", "")
+    assert "Voice profile:" not in prompt
+    assert "Sourdough rise tips" in prompt
+    assert "Return only the post text" in prompt
+
+
+def test_build_prompt_includes_voice_section_when_profile_set():
+    prompt = _build_prompt("Sourdough rise tips", "Wry baker.")
+    assert "Voice profile:\nWry baker." in prompt
+    assert "Topic: Sourdough rise tips" in prompt
+
+
+def test_generate_post_raises_on_empty_topic():
+    with pytest.raises(GeneratorError, match="topic must not be empty"):
+        generate_post("")
+
+
+def test_generate_post_raises_on_whitespace_topic():
+    with pytest.raises(GeneratorError, match="topic must not be empty"):
+        generate_post("   \n   ")
+
+
+def test_generate_post_raises_on_unknown_provider():
+    with pytest.raises(GeneratorError, match="Unknown AI provider"):
+        generate_post("topic", provider="nonsense")
+
+
+def test_generate_post_uses_provider_argument_over_env(monkeypatch, tmp_path: Path):
+    monkeypatch.setenv("AI_PROVIDER", "openai")
+    monkeypatch.chdir(tmp_path)
+    with patch.dict(
+        "content.generator._PROVIDERS",
+        {"claude": lambda prompt: "claude:" + prompt[:20]},
+    ):
+        result = generate_post("Sourdough", provider="claude")
+    assert result.startswith("claude:")
+
+
+def test_generate_post_falls_back_to_env_when_no_provider_arg(monkeypatch, tmp_path: Path):
+    monkeypatch.setenv("AI_PROVIDER", "openai")
+    monkeypatch.chdir(tmp_path)
+    with patch.dict(
+        "content.generator._PROVIDERS",
+        {"openai": lambda prompt: "openai:" + prompt[:20]},
+    ):
+        result = generate_post("Sourdough")
+    assert result.startswith("openai:")
+
+
+def test_generate_post_defaults_to_claude_when_env_unset(monkeypatch, tmp_path: Path):
+    monkeypatch.delenv("AI_PROVIDER", raising=False)
+    monkeypatch.chdir(tmp_path)
+    with patch.dict(
+        "content.generator._PROVIDERS",
+        {"claude": lambda prompt: "claude-default"},
+    ):
+        result = generate_post("Sourdough")
+    assert result == "claude-default"
+
+
+def test_generate_post_normalises_provider_case(monkeypatch, tmp_path: Path):
+    monkeypatch.chdir(tmp_path)
+    with patch.dict(
+        "content.generator._PROVIDERS",
+        {"claude": lambda prompt: "ok"},
+    ):
+        assert generate_post("topic", provider="CLAUDE") == "ok"
+
+
+def test_generate_post_passes_prompt_with_voice_profile(tmp_path: Path):
+    (tmp_path / "voice.md").write_text("Terse.", encoding="utf-8")
+    captured: dict[str, str] = {}
+
+    def fake_provider(prompt: str) -> str:
+        captured["prompt"] = prompt
+        return "draft"
+
+    with patch.dict("content.generator._PROVIDERS", {"claude": fake_provider}):
+        generate_post("Sourdough", provider="claude", project_root=tmp_path)
+
+    assert "Voice profile:\nTerse." in captured["prompt"]
+    assert "Topic: Sourdough" in captured["prompt"]
+
+
+def test_generate_post_explicit_voice_profile_overrides_files(tmp_path: Path):
+    (tmp_path / "voice.md").write_text("FILE_VOICE", encoding="utf-8")
+    captured: dict[str, str] = {}
+
+    def fake_provider(prompt: str) -> str:
+        captured["prompt"] = prompt
+        return "draft"
+
+    with patch.dict("content.generator._PROVIDERS", {"claude": fake_provider}):
+        generate_post(
+            "Sourdough",
+            voice_profile="EXPLICIT",
+            provider="claude",
+            project_root=tmp_path,
+        )
+
+    assert "EXPLICIT" in captured["prompt"]
+    assert "FILE_VOICE" not in captured["prompt"]
+
+
+def test_generate_post_explicit_empty_voice_profile_suppresses_section(tmp_path: Path):
+    (tmp_path / "voice.md").write_text("FILE_VOICE", encoding="utf-8")
+    captured: dict[str, str] = {}
+
+    def fake_provider(prompt: str) -> str:
+        captured["prompt"] = prompt
+        return "draft"
+
+    with patch.dict("content.generator._PROVIDERS", {"claude": fake_provider}):
+        generate_post(
+            "Sourdough",
+            voice_profile="",
+            provider="claude",
+            project_root=tmp_path,
+        )
+
+    assert "Voice profile:" not in captured["prompt"]
+    assert "FILE_VOICE" not in captured["prompt"]
+
+
+def test_generate_post_wraps_provider_exception_in_generator_error():
+    def boom(prompt: str) -> str:
+        raise RuntimeError("upstream 500")
+
+    with patch.dict("content.generator._PROVIDERS", {"claude": boom}):
+        with pytest.raises(GeneratorError, match="claude generation failed: upstream 500"):
+            generate_post("topic", provider="claude")
+
+
+def test_generate_post_wraps_missing_sdk_with_install_hint():
+    def missing_sdk(prompt: str) -> str:
+        raise ImportError("No module named 'anthropic'")
+
+    with patch.dict("content.generator._PROVIDERS", {"claude": missing_sdk}):
+        with pytest.raises(GeneratorError, match="pip install claude"):
+            generate_post("topic", provider="claude")
+
+
+def test_generate_post_passes_through_generator_error_unchanged():
+    def already_clean(prompt: str) -> str:
+        raise GeneratorError("GOOGLE_AI_API_KEY is not set in the environment")
+
+    with patch.dict("content.generator._PROVIDERS", {"gemini": already_clean}):
+        with pytest.raises(GeneratorError, match="GOOGLE_AI_API_KEY is not set"):
+            generate_post("topic", provider="gemini")


### PR DESCRIPTION
## What this changes

Adds the dashboard's AI compose backend. First half of issue #3.

- New `content/generator.py` with a three-provider abstraction (Claude, OpenAI, Gemini). Provider is chosen by `AI_PROVIDER` in `.env` (default `claude`). Provider SDKs are imported lazily so users install only the one they actually use.
- New `POST /generate` route in `dashboard/app.py`. Takes a `topic` form field, returns the generated post text as plain HTML for the Sparkles button to drop into the compose textarea.
- Voice tuning is automatic: if `about-me.md` or `voice.md` exist at the project root, their contents are prepended to every prompt as the voice profile.

## Why

Issue #3 says "the whole product story is AI drafts in your voice." Right now AI is only used in the static skill workflows. This wires a real provider into the dashboard so the Sparkles button (landing in the follow-up UI PR) has something to call.

## Approval-queue safety check

- [x] This change does not add a new write action

The AI generates a draft. The user still picks platforms, edits the text, and submits to the approval queue. The post then goes through the same human-approval gate as anything else. No silent automation.

## Verification

- [x] 24 new pytest tests across `tests/test_generator.py` (19) and `tests/test_generate_route.py` (5). Provider SDKs are not exercised. The tests patch `content.generator._PROVIDERS` directly, so they pass even with `anthropic`, `openai`, and `google-generativeai` all uninstalled.
- [x] Coverage: voice profile loading (none / about-me only / voice only / both), prompt construction (with and without voice), provider resolution (arg over env, env when no arg, default to claude, case-normalising), error wrapping (ImportError to install hint, generic Exception to `GeneratorError`, `GeneratorError` pass-through), and the HTTP route (200 happy path, 400 on empty / whitespace topic, 500 on `GeneratorError`, whitespace-stripping).
- [x] Full suite: `pytest tests/` runs 105 tests, all green, in ~23s on Python 3.13.
- [x] Smoke import: `python -c "from dashboard import app"` boots cleanly with dummy env vars.

## What lands in the follow-up UI PR

- Sparkles button in `dashboard/templates/index.html`'s compose toolbar
- Inline popover with a "What is this post about?" input and Generate button
- JS to call `/generate` and drop the response into the textarea
- CSS to style the popover

## Screenshots / recording

n/a, no UI change in this PR. The follow-up will include screenshots of the Sparkles flow.