### PR TITLE
feat: wire Sparkles button to /generate (closes #3)

### DIFF
--- a/dashboard/templates/index.html
+++ b/dashboard/templates/index.html
@@ -109,6 +109,13 @@
                   placeholder="What's on your mind? Drafts go to the approval queue."
                   oninput="document.getElementById('bccCount').textContent=this.value.length"
                   required></textarea>
+        <div id="bAiRow" class="img-row ai-row" style="display:none;">
+          <span class="img-label">AI prompt</span>
+          <input type="text" id="bAiTopic" placeholder="What is this post about?" class="img-input"
+                 onkeydown="if(event.key==='Enter'){event.preventDefault();generateBroadcastDraft();}">
+          <button type="button" id="bAiGenBtn" class="btn btn-sm" onclick="generateBroadcastDraft()">Generate</button>
+          <span id="bAiStatus" class="img-hint"></span>
+        </div>
         <div id="bImgRow" class="img-row" style="display:none;">
           <span class="img-label">Image URL</span>
           <input type="url" name="image_url" id="bImg" placeholder="https://example.com/image.jpg" class="img-input">
@@ -117,6 +124,9 @@
       </div>
       <div class="compose-footer">
         <div class="compose-toolbar">
+          <button type="button" data-tip="Generate with AI" onclick="toggleBroadcastAi()">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M12 3l1.5 4.5L18 9l-4.5 1.5L12 15l-1.5-4.5L6 9l4.5-1.5L12 3z" stroke-linecap="round" stroke-linejoin="round"/><path d="M19 14l.7 2.3L22 17l-2.3.7L19 20l-.7-2.3L16 17l2.3-.7L19 14z" stroke-linecap="round" stroke-linejoin="round"/></svg>
+          </button>
           <button type="button" data-tip="Toggle image" onclick="toggleBroadcastImage()">
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><rect x="3" y="3" width="18" height="18" rx="2"/><circle cx="8.5" cy="8.5" r="1.5"/><path d="M21 15l-5-5L5 21"/></svg>
           </button>
@@ -203,6 +213,54 @@
   function toggleBroadcastImage() {
     const r = document.getElementById('bImgRow');
     r.style.display = (r.style.display === 'none') ? 'flex' : 'none';
+  }
+
+  function toggleBroadcastAi() {
+    const row = document.getElementById('bAiRow');
+    const showing = row.style.display === 'none';
+    row.style.display = showing ? 'flex' : 'none';
+    if (showing) {
+      document.getElementById('bAiStatus').textContent = '';
+      document.getElementById('bAiTopic').focus();
+    }
+  }
+
+  async function generateBroadcastDraft() {
+    const topicEl = document.getElementById('bAiTopic');
+    const status = document.getElementById('bAiStatus');
+    const btn = document.getElementById('bAiGenBtn');
+    const topic = topicEl.value.trim();
+    if (!topic) {
+      status.textContent = 'Type a topic first.';
+      topicEl.focus();
+      return;
+    }
+    btn.disabled = true;
+    status.textContent = 'Generating...';
+    try {
+      const res = await fetch('/generate', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body: new URLSearchParams({ topic }),
+      });
+      if (!res.ok) {
+        const errText = (await res.text()).trim();
+        status.textContent = errText.slice(0, 200) || 'Generate failed.';
+        return;
+      }
+      const text = (await res.text()).trim();
+      const ta = document.getElementById('bMsg');
+      ta.value = text;
+      ta.dispatchEvent(new Event('input'));
+      ta.focus();
+      status.textContent = '';
+      topicEl.value = '';
+      document.getElementById('bAiRow').style.display = 'none';
+    } catch (err) {
+      status.textContent = 'Network error.';
+    } finally {
+      btn.disabled = false;
+    }
   }
 
   // Auto-show image row when Instagram is checked

--- a/tests/test_compose_ui.py
+++ b/tests/test_compose_ui.py
@@ -1,0 +1,36 @@
+"""Render-level tests for the compose UI's AI Sparkles button.
+
+These confirm the index template parses and includes the elements the
+generate flow depends on. We do not run any JavaScript, so the actual
+Sparkles click flow is exercised end-to-end only by manual smoke.
+"""
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from dashboard import app as dash_app
+
+
+def test_index_renders_sparkles_button():
+    client = TestClient(dash_app.app)
+    response = client.get("/")
+    assert response.status_code == 200
+    assert "toggleBroadcastAi" in response.text
+    assert "Generate with AI" in response.text
+
+
+def test_index_renders_ai_prompt_row():
+    client = TestClient(dash_app.app)
+    response = client.get("/")
+    assert response.status_code == 200
+    assert 'id="bAiRow"' in response.text
+    assert 'id="bAiTopic"' in response.text
+    assert 'id="bAiGenBtn"' in response.text
+    assert "What is this post about?" in response.text
+
+
+def test_index_wires_generate_handler_to_button():
+    client = TestClient(dash_app.app)
+    response = client.get("/")
+    assert "generateBroadcastDraft" in response.text
+    assert "/generate" in response.text


### PR DESCRIPTION
## What this changes

Wires the dashboard's compose Sparkles button to the AI generate backend that landed in #24. Closes issue #3 end to end.

- New Sparkles button in the broadcast compose toolbar, next to the existing image toggle.
- New inline AI prompt row under the textarea (mirrors the `.img-row` pattern already used for the image URL field). Hidden by default, opens when Sparkles is clicked.
- The user types a topic, hits Enter or clicks Generate, and the response from `POST /generate` is dropped into the message textarea. The user can edit the draft before adding it to the approval queue.
- Status text reports failures inline. Network errors and HTTP error responses surface in the same place rather than crashing the form.
- Reuses `.img-row`, `.img-input`, `.img-label`, `.img-hint`, and `.btn .btn-sm` styles. No new CSS.

## Why

Issue #3, second half. The first half (#24) added the provider abstraction and the `POST /generate` route. This PR makes that route reachable from the actual UI, which closes the issue end to end.

## Approval-queue safety check

- [x] This change does not add a new write action

The Sparkles button generates a draft. The user still picks platforms, reviews the draft, and submits to the approval queue. The post then goes through the same human-approval gate as anything else. No silent automation.

## Verification

- [x] 3 new render tests in `tests/test_compose_ui.py`. They confirm the template parses and the Sparkles button, AI row, and `/generate` wiring are all present in the rendered HTML for `/`.
- [x] Full suite: `pytest tests/` runs 108 tests, all green, in ~25s on Python 3.13.
- [x] Smoke import: `python -c "from dashboard import app"` boots cleanly with dummy env vars.

## Manual smoke

I have not exercised the live click-through against a real provider. To do that locally:

1. `pip install anthropic` (or `openai` / `google-generativeai`).
2. Add the matching API key to `.env` (and optionally `AI_PROVIDER=`).
3. Optionally drop an `about-me.md` and/or `voice.md` in the project root for voice tuning.
4. `python -m dashboard.app`, click "New post", click the Sparkles icon, type a topic, click Generate.

## Screenshots / recording

n/a from CI. The UI is a single inline row using existing styling, no new visual primitives.