### PR TITLE
chore: pin requirements with floor + next-major cap

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,7 @@
 # Dev-only dependencies. Install with: pip install -r requirements-dev.txt
 # Runtime deps still live in requirements.txt.
+#
+# Same pinning policy as requirements.txt: floor version plus next-major cap.
 
-pytest
-ruff
+pytest>=9.0,<10
+ruff>=0.15,<1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,17 @@
-mcp
-python-dotenv
-requests
-fastapi
-uvicorn[standard]
-jinja2
-python-multipart
+# Runtime dependencies for Social Auto Engine.
+#
+# Pinned with a floor version and a cap at the next major. This keeps
+# installs reproducible while still allowing patch updates. The AI
+# compose feature's provider SDKs (anthropic, openai,
+# google-generativeai) are intentionally omitted from this file.
+# Install only the one matching your AI_PROVIDER. See CONTRIBUTING.md.
+
+mcp>=1.27,<2
+python-dotenv>=1.2,<2
+requests>=2.28,<3
+fastapi>=0.136,<1
+uvicorn[standard]>=0.46,<1
+jinja2>=3.1,<4
+python-multipart>=0.0.27,<1
 apscheduler>=3.10,<4
-sqlalchemy>=2.0
+sqlalchemy>=2.0,<3


### PR DESCRIPTION
## What this changes

Pins `requirements.txt` and `requirements-dev.txt` with a floor version + next-major cap on every entry.

Before:
```
mcp
python-dotenv
requests
fastapi
uvicorn[standard]
jinja2
python-multipart
apscheduler>=3.10,<4
sqlalchemy>=2.0
```

After:
```
mcp>=1.27,<2
python-dotenv>=1.2,<2
requests>=2.28,<3
fastapi>=0.136,<1
uvicorn[standard]>=0.46,<1
jinja2>=3.1,<4
python-multipart>=0.0.27,<1
apscheduler>=3.10,<4
sqlalchemy>=2.0,<3
```

Same pinning policy applied to `requirements-dev.txt`:

```
pytest>=9.0,<10
ruff>=0.15,<1
```

## Why

Today an unpinned `requirements.txt` lets a new contributor's `pip install` pull in any major-version bump from any of these projects. That is how a "fresh clone" install starts breaking on a quiet Tuesday. Floors guarantee features the codebase relies on are available. Caps stop major-version surprises from reaching the install step. Patches still flow.

Floors are set to whatever I have running locally today (verified in the maintainer's env), so this is not asking anyone to chase brand-new releases.

The AI compose provider SDKs (`anthropic`, `openai`, `google-generativeai`) stay out of this file on purpose. Users install only the one matching their `AI_PROVIDER`. That's documented in CONTRIBUTING.md.

## Approval-queue safety check

- [x] This change does not add a new write action

## Verification

- [x] `pytest tests/` runs 108 tests, all green, in ~26s on Python 3.13. CI's pytest job runs against the new pins.
- [x] CI's smoke-import jobs (`python -c "import server"` and `from dashboard import app`) cover the runtime deps.
- [x] Diff is `+20 / -10` across two files. No code changes.

## Screenshots / recording

n/a, infra-only.