### PR TITLE
fix: bump gemini model name to gemini-2.5-flash

### DIFF
--- a/content/generator.py
+++ b/content/generator.py
@@ -21,7 +21,11 @@ from typing import Callable
 
 CLAUDE_MODEL = "claude-sonnet-4-6"
 OPENAI_MODEL = "gpt-4o-mini"
-GEMINI_MODEL = "gemini-1.5-flash"
+# Note: the `google.generativeai` package itself is deprecated in favour
+# of `google.genai`. Migrating the SDK is tracked separately. Until then
+# we use a current GA model name; `gemini-1.5-flash` no longer resolves
+# on the v1beta endpoint.
+GEMINI_MODEL = "gemini-2.5-flash"
 MAX_OUTPUT_TOKENS = 400
 
 


### PR DESCRIPTION
## What this changes

Bumps `GEMINI_MODEL` from `gemini-1.5-flash` to `gemini-2.5-flash` in `content/generator.py`. Adds a one-line comment above the constant flagging that the `google.generativeai` package itself is deprecated.

## Why

Live testing of the AI compose Sparkles flow with `AI_PROVIDER=gemini` returned a 500 from `POST /generate` carrying:

```
404 models/gemini-1.5-flash is not found for API version v1beta, or is not supported for generateContent
```

The `gemini-1.5-flash` name no longer resolves on the v1beta endpoint. `gemini-2.5-flash` is the current generally-available fast-tier model in the same speed and cost class, and resolves cleanly. Sparkles now works end to end on Gemini.

The package deprecation note is a separate follow-up: `google.generativeai` is replaced by `google.genai`. The migration is a real refactor (different client API shape, different model-call conventions). Tracking that separately so this PR stays surgical.

## Approval-queue safety check

- [x] This change does not add a new write action

## Verification

- [x] `pytest tests/test_generator.py` still passes 19/19. The tests patch `_PROVIDERS` at the function level so they never hit the real Gemini API; the change is invisible to the suite.
- [x] Manual: with `AI_PROVIDER=gemini` and `GOOGLE_AI_API_KEY` set, `POST /generate` returns 200 with a real generated draft.
- [x] Diff is `+5 / -1` in one file. No code path changes, only the model constant and an explanatory note.

## Screenshots / recording

n/a, model-constant fix.