### PR TITLE
feat: dashboard UI overhaul with design system, modals, search, and edit

### DIFF
--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -831,6 +831,52 @@ async def clear_ai_keys(request: Request, service: str):
     return response
 
 
+@app.post("/edit/{post_id}", response_class=HTMLResponse)
+async def edit_post(
+    request: Request,
+    post_id: int,
+    message: str = Form(""),
+    image_url: str = Form(""),
+    video_url: str = Form(""),
+):
+    """Update message, image, or video URL of a pending post."""
+    post = db.get_post(post_id)
+    if not post:
+        raise HTTPException(404)
+    if post["status"] != "pending":
+        raise HTTPException(409, f"Post is {post['status']}, cannot edit")
+    updates: dict = {}
+    if message.strip():
+        updates["message"] = message.strip()
+    updates["image_url"] = image_url.strip() or None
+    updates["video_url"] = video_url.strip() or None
+    if updates:
+        db.update_post(post_id, **updates)
+    return _refresh_all(request, toast=("success", f"Post #{post_id} updated"))
+
+
+@app.get("/search", response_class=HTMLResponse)
+async def search(request: Request, q: str = "", status: str = ""):
+    """HTMX live search endpoint. Returns filtered _columns.html fragment."""
+    results = db.search_posts(q=q, status=status, limit=50)
+    pending = [p for p in results if p["status"] == "pending" and not p.get("group_id")]
+    published = [p for p in results if p["status"] == "published"]
+    failed = [p for p in results if p["status"] == "failed"]
+    rejected = [p for p in results if p["status"] == "rejected"]
+    return templates.TemplateResponse(
+        request,
+        "_columns.html",
+        {
+            "pending": pending,
+            "pending_groups": [],
+            "published": published,
+            "failed": failed,
+            "rejected": rejected,
+            "stats": db.stats(),
+        },
+    )
+
+
 @app.post("/approve/{post_id}", response_class=HTMLResponse)
 async def approve(request: Request, post_id: int):
     post = db.get_post(post_id)

--- a/dashboard/db.py
+++ b/dashboard/db.py
@@ -271,6 +271,25 @@ def calendar_posts(start_iso: str, end_iso: str):
         return [dict(r) for r in rows]
 
 
+def search_posts(q: str = "", status: str = "", limit: int = 50) -> list[dict]:
+    """Full-text search across post messages with optional status filter."""
+    with connect() as conn:
+        clauses = []
+        params: list = []
+        if q.strip():
+            clauses.append("message LIKE ?")
+            params.append(f"%{q.strip()}%")
+        if status.strip():
+            clauses.append("status = ?")
+            params.append(status.strip())
+        where = " AND ".join(clauses) if clauses else "1=1"
+        rows = conn.execute(
+            f"SELECT * FROM post WHERE {where} ORDER BY created_at DESC LIMIT ?",
+            params + [limit],
+        ).fetchall()
+        return [dict(r) for r in rows]
+
+
 def stats():
     with connect() as conn:
         rows = conn.execute(

--- a/dashboard/static/styles.css
+++ b/dashboard/static/styles.css
@@ -48,9 +48,48 @@
   --font-sans: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
   --font-mono: 'JetBrains Mono', 'Fira Code', ui-monospace, monospace;
 
+  /* Platform brand colours */
+  --c-facebook: #1877F2;
+  --c-instagram: #E1306C;
+  --c-threads: #000000;
+  --c-whatsapp: #25D366;
+  --c-linkedin: #0A66C2;
+  --c-tiktok: #00f2ea;
+  --c-youtube: #FF0000;
+  --c-x: #000000;
+
   /* Layout */
   --sidebar-w: 220px;
   --header-h: 48px;
+}
+
+/* ─── Light theme ───────────────────────────── */
+[data-theme="light"] {
+  --bg: #f7f7f8;
+  --bg-sidebar: #ffffff;
+  --bg-elevated: #ffffff;
+  --bg-hover: #f0f0f2;
+  --bg-active: #e8e8ec;
+  --border: rgba(0, 0, 0, 0.07);
+  --border-strong: rgba(0, 0, 0, 0.12);
+  --border-active: rgba(0, 0, 0, 0.2);
+  --text: rgba(0, 0, 0, 0.92);
+  --text-secondary: rgba(0, 0, 0, 0.6);
+  --text-tertiary: rgba(0, 0, 0, 0.4);
+  --text-quaternary: rgba(0, 0, 0, 0.2);
+  --accent-bg: rgba(123, 97, 255, 0.06);
+  --accent-bg-strong: rgba(123, 97, 255, 0.12);
+  --status-neutral: rgba(0, 0, 0, 0.2);
+  --c-threads: #333;
+  --c-x: #333;
+}
+[data-theme="light"] .topbar {
+  background: rgba(247, 247, 248, 0.85);
+}
+[data-theme="light"] .platform-icon.x,
+[data-theme="light"] .platform-icon.th,
+[data-theme="light"] .platform-icon.tt {
+  border: 1px solid var(--border-strong);
 }
 
 *, ::before, ::after { box-sizing: border-box; }
@@ -374,9 +413,19 @@ a { color: inherit; text-decoration: none; }
 }
 
 .compose:focus-within {
-  border-color: var(--border-active);
-  box-shadow: 0 0 0 1px var(--accent-border), 0 0 20px -8px rgba(123, 97, 255, 0.1);
+  border-color: var(--accent-border);
+  box-shadow: 0 0 0 1px var(--accent-border), 0 0 24px -6px rgba(123, 97, 255, 0.15);
 }
+.compose:focus-within::before {
+  content: '';
+  position: absolute;
+  top: 0; left: 0; right: 0;
+  height: 2px;
+  background: var(--gradient);
+  border-radius: var(--r-md) var(--r-md) 0 0;
+  z-index: 1;
+}
+.compose { position: relative; }
 
 .compose-header {
   padding: var(--sp-2) var(--sp-4);
@@ -459,15 +508,28 @@ textarea::placeholder { color: var(--text-tertiary); }
   gap: var(--sp-1);
 }
 
-.compose-toolbar button {
-  display: grid; place-items: center;
-  width: 24px; height: 24px;
+.compose-toolbar button,
+.compose-toolbar .toolbar-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 3px 8px;
+  height: 28px;
   border-radius: var(--r-sm);
   color: var(--text-tertiary);
-  transition: background 80ms, color 80ms;
+  border: 1px solid transparent;
+  transition: background 100ms, color 100ms, border-color 100ms;
+  font-size: 10.5px;
+  font-weight: 500;
 }
-.compose-toolbar button:hover { background: var(--bg-hover); color: var(--text); }
-.compose-toolbar button svg { width: 13px; height: 13px; stroke-width: 1.75; }
+.compose-toolbar button:hover,
+.compose-toolbar .toolbar-btn:hover {
+  background: var(--accent-bg);
+  color: var(--accent);
+  border-color: var(--accent-border);
+}
+.compose-toolbar button svg { width: 13px; height: 13px; stroke-width: 1.75; flex-shrink: 0; }
+.toolbar-label { white-space: nowrap; }
 
 .char-count {
   font-size: 10.5px;
@@ -691,6 +753,7 @@ textarea::placeholder { color: var(--text-tertiary); }
   border: 1px solid var(--border);
   border-radius: var(--r-md);
   overflow: hidden;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.15), 0 0 0 0.5px var(--border);
 }
 
 .post-row {
@@ -705,7 +768,8 @@ textarea::placeholder { color: var(--text-tertiary); }
 }
 
 .post-row:last-child { border-bottom: none; }
-.post-row:hover { background: var(--bg-hover); }
+.post-row:hover { background: var(--bg-hover); transform: translateX(1px); }
+.post-row { transition: background 80ms, transform 120ms ease-out; }
 
 @keyframes rowIn {
   from { opacity: 0; transform: translateY(-2px); }
@@ -764,7 +828,10 @@ textarea::placeholder { color: var(--text-tertiary); }
   background: rgba(234, 179, 8, 0.03);
   position: relative;
 }
-.post-row.pending:hover { background: rgba(234, 179, 8, 0.07); }
+.post-row.pending:hover {
+  background: rgba(234, 179, 8, 0.07);
+  box-shadow: inset 0 0 0 1px rgba(234, 179, 8, 0.08);
+}
 .post-row.pending .post-message { white-space: normal; }
 .post-row.pending .post-actions { opacity: 1; }
 
@@ -855,20 +922,23 @@ textarea::placeholder { color: var(--text-tertiary); }
 
 /* ─── Empty state ────────────────────────────── */
 .empty {
-  padding: var(--sp-10) var(--sp-6);
+  padding: var(--sp-12) var(--sp-6);
   text-align: center;
   color: var(--text-tertiary);
+  border: 1px dashed var(--border-strong);
+  border-radius: var(--r-md);
+  margin: var(--sp-2);
 }
 
 .empty-icon {
-  width: 32px; height: 32px;
-  margin: 0 auto var(--sp-3);
-  border-radius: 7px;
-  background: var(--bg-hover);
+  width: 48px; height: 48px;
+  margin: 0 auto var(--sp-4);
+  border-radius: 50%;
+  background: radial-gradient(circle, var(--accent-bg) 0%, var(--bg-hover) 100%);
   display: grid; place-items: center;
   border: 1px solid var(--border);
 }
-.empty-icon svg { width: 16px; height: 16px; stroke-width: 1.5; color: var(--text-tertiary); }
+.empty-icon svg { width: 20px; height: 20px; stroke-width: 1.5; color: var(--text-tertiary); }
 
 .empty-title {
   font-size: 13px;
@@ -1992,6 +2062,197 @@ textarea:focus-visible { outline: none; box-shadow: inset 0 0 0 1px var(--accent
 [dir="rtl"] .compose-footer { flex-direction: row-reverse; }
 [dir="rtl"] .post-actions { margin-left: 0; margin-right: auto; }
 [dir="rtl"] .lang-picker { display: flex; gap: var(--sp-2); flex-wrap: wrap; }
+
+/* ─── Post thumbnail in queue ───────────────── */
+.post-thumb {
+  width: 40px; height: 40px;
+  border-radius: var(--radius);
+  object-fit: cover;
+  flex-shrink: 0;
+  border: 1px solid var(--border);
+}
+
+/* ─── Inline media preview ──────────────────── */
+.media-preview {
+  width: 48px; height: 48px;
+  border-radius: var(--radius);
+  object-fit: cover;
+  border: 1px solid var(--border);
+  flex-shrink: 0;
+}
+
+/* ─── Character counter pills ────────────────── */
+.char-counter {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-2);
+}
+.char-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  padding: 1px 6px;
+  border-radius: 99px;
+  font-size: 10px;
+  font-family: var(--font-mono);
+  font-weight: 500;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  color: var(--text-tertiary);
+  transition: border-color 150ms, color 150ms;
+}
+.char-pill.warn {
+  border-color: rgba(234, 179, 8, 0.4);
+  color: var(--status-pending);
+}
+.char-pill.over {
+  border-color: rgba(239, 68, 68, 0.4);
+  color: var(--status-error);
+}
+.char-pill .char-pill-icon {
+  width: 12px; height: 12px;
+  border-radius: 3px;
+  display: grid; place-items: center;
+  font-size: 7px; font-weight: 700;
+  color: #fff;
+}
+.char-pill .char-pill-count { font-variant-numeric: tabular-nums; }
+.char-pill .char-pill-max { opacity: 0.5; }
+
+/* ─── Search bar ────────────────────────────── */
+.search-bar {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-2);
+  padding: var(--sp-2) var(--sp-3);
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+  border-radius: var(--r-md);
+  margin-bottom: var(--sp-4);
+  transition: border-color 150ms;
+}
+.search-bar:focus-within {
+  border-color: var(--accent-border);
+  box-shadow: 0 0 0 1px var(--accent-border);
+}
+.search-bar svg {
+  width: 14px; height: 14px;
+  stroke-width: 1.75;
+  color: var(--text-tertiary);
+  flex-shrink: 0;
+}
+.search-bar input[type="search"] {
+  flex: 1;
+  background: transparent;
+  border: none;
+  color: var(--text);
+  font-size: 13px;
+  outline: none;
+  min-width: 0;
+}
+.search-bar input[type="search"]::placeholder { color: var(--text-tertiary); }
+.search-bar input[type="search"]::-webkit-search-cancel-button { -webkit-appearance: none; }
+.search-bar select {
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: var(--r-sm);
+  color: var(--text-secondary);
+  font-size: 11.5px;
+  padding: 3px 8px;
+  outline: none;
+  cursor: pointer;
+}
+.search-bar .search-kbd {
+  font-size: 10px;
+  color: var(--text-quaternary);
+  margin-left: auto;
+}
+
+/* ─── Confirm / Edit modal ──────────────────── */
+.modal-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.55);
+  backdrop-filter: blur(4px);
+  display: grid;
+  place-items: center;
+  z-index: 150;
+  animation: fadeIn 120ms ease-out;
+}
+@keyframes fadeIn {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+.modal-card {
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-strong);
+  border-radius: var(--r-lg);
+  padding: var(--sp-6);
+  max-width: 520px;
+  width: 90vw;
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.4);
+  animation: slideDown 200ms cubic-bezier(0.2, 0.9, 0.32, 1.05);
+}
+.modal-title {
+  font-size: 16px;
+  font-weight: 600;
+  margin: 0 0 var(--sp-2);
+}
+.modal-message {
+  font-size: 13px;
+  color: var(--text-secondary);
+  margin: 0 0 var(--sp-5);
+  line-height: 1.5;
+}
+.modal-form {
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-3);
+  margin-bottom: var(--sp-5);
+}
+.modal-form textarea {
+  min-height: 100px;
+  background: var(--bg);
+  border: 1px solid var(--border-strong);
+  border-radius: var(--r-sm);
+  padding: var(--sp-2) var(--sp-3);
+  font-size: 13px;
+}
+.modal-form textarea:focus {
+  border-color: var(--accent-border);
+  box-shadow: 0 0 0 1px var(--accent-border);
+}
+.modal-form input {
+  background: var(--bg);
+  border: 1px solid var(--border-strong);
+  border-radius: var(--r-sm);
+  padding: var(--sp-2) var(--sp-3);
+  font-size: 13px;
+  color: var(--text);
+  outline: none;
+  width: 100%;
+  box-sizing: border-box;
+}
+.modal-form input:focus {
+  border-color: var(--accent-border);
+  box-shadow: 0 0 0 1px var(--accent-border);
+}
+.modal-form label {
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--text-tertiary);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+.modal-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: var(--sp-2);
+}
+
+/* ─── Theme toggle ──────────────────────────── */
+.theme-toggle svg { transition: transform 200ms ease; }
+.theme-toggle:hover svg { transform: rotate(15deg); }
 
 @media (prefers-reduced-motion: reduce) {
   *, ::before, ::after {

--- a/dashboard/templates/_base.html
+++ b/dashboard/templates/_base.html
@@ -103,6 +103,10 @@
       </div>
       <div class="topbar-actions">
         {% block topbar_actions %}{% endblock %}
+        <button class="btn btn-ghost btn-icon theme-toggle" id="themeToggle" onclick="toggleTheme()" data-tip="Toggle theme">
+          <svg id="themeIconDark" viewBox="0 0 24 24" fill="none" stroke="currentColor" width="14" height="14"><path d="M21 12.79A9 9 0 1111.21 3a7 7 0 009.79 9.79z" stroke-linecap="round" stroke-linejoin="round"/></svg>
+          <svg id="themeIconLight" viewBox="0 0 24 24" fill="none" stroke="currentColor" width="14" height="14" style="display:none;"><circle cx="12" cy="12" r="5"/><path d="M12 1v2M12 21v2M4.22 4.22l1.42 1.42M18.36 18.36l1.42 1.42M1 12h2M21 12h2M4.22 19.78l1.42-1.42M18.36 5.64l1.42-1.42" stroke-linecap="round" stroke-linejoin="round"/></svg>
+        </button>
       </div>
     </header>
 
@@ -115,6 +119,141 @@
 </div>
 
 {% include "_toast.html" %}
+
+{# ─── Confirm modal ─────────────────────────────── #}
+<div id="confirmModal" class="modal-overlay" style="display:none;" onclick="if(event.target===this)closeModal()">
+  <div class="modal-card">
+    <h3 class="modal-title" id="confirmTitle">Confirm</h3>
+    <p class="modal-message" id="confirmMessage"></p>
+    <div class="modal-actions">
+      <button class="btn btn-secondary btn-sm" onclick="closeModal()">Cancel</button>
+      <button class="btn btn-primary btn-sm" id="confirmAction">Confirm</button>
+    </div>
+  </div>
+</div>
+
+{# ─── Edit modal ────────────────────────────────── #}
+<div id="editModal" class="modal-overlay" style="display:none;" onclick="if(event.target===this)closeEditModal()">
+  <div class="modal-card">
+    <h3 class="modal-title">Edit post</h3>
+    <form id="editForm" class="modal-form">
+      <input type="hidden" id="editPostId">
+      <div>
+        <label>Message</label>
+        <textarea id="editMessage" placeholder="Post message"></textarea>
+      </div>
+      <div>
+        <label>Image URL</label>
+        <input type="url" id="editImageUrl" placeholder="https://example.com/image.jpg">
+      </div>
+      <div>
+        <label>Video URL</label>
+        <input type="url" id="editVideoUrl" placeholder="https://example.com/video.mp4">
+      </div>
+    </form>
+    <div class="modal-actions">
+      <button class="btn btn-secondary btn-sm" onclick="closeEditModal()">Cancel</button>
+      <button class="btn btn-primary btn-sm" onclick="saveEdit()">Save changes</button>
+    </div>
+  </div>
+</div>
+
+<script>
+  // ── Theme ──────────────────────────────────────
+  function toggleTheme() {
+    const html = document.documentElement;
+    const current = html.getAttribute('data-theme');
+    const next = current === 'light' ? '' : 'light';
+    if (next) html.setAttribute('data-theme', 'light');
+    else html.removeAttribute('data-theme');
+    localStorage.setItem('theme', next || 'dark');
+    updateThemeIcon();
+  }
+  function updateThemeIcon() {
+    const isLight = document.documentElement.getAttribute('data-theme') === 'light';
+    const d = document.getElementById('themeIconDark');
+    const l = document.getElementById('themeIconLight');
+    if (d) d.style.display = isLight ? 'none' : '';
+    if (l) l.style.display = isLight ? '' : 'none';
+  }
+  (function initTheme() {
+    const saved = localStorage.getItem('theme');
+    if (saved === 'light') document.documentElement.setAttribute('data-theme', 'light');
+    updateThemeIcon();
+  })();
+
+  // ── Modals ─────────────────────────────────────
+  function showConfirm(title, message, onConfirm) {
+    document.getElementById('confirmTitle').textContent = title;
+    document.getElementById('confirmMessage').textContent = message;
+    const modal = document.getElementById('confirmModal');
+    modal.style.display = '';
+    const btn = document.getElementById('confirmAction');
+    const clone = btn.cloneNode(true);
+    btn.parentNode.replaceChild(clone, btn);
+    clone.id = 'confirmAction';
+    clone.addEventListener('click', () => { closeModal(); onConfirm(); });
+  }
+  function closeModal() { document.getElementById('confirmModal').style.display = 'none'; }
+
+  function openEditModal(postId, message, imageUrl, videoUrl) {
+    document.getElementById('editPostId').value = postId;
+    document.getElementById('editMessage').value = message || '';
+    document.getElementById('editImageUrl').value = imageUrl || '';
+    document.getElementById('editVideoUrl').value = videoUrl || '';
+    document.getElementById('editModal').style.display = '';
+    document.getElementById('editMessage').focus();
+  }
+  function closeEditModal() { document.getElementById('editModal').style.display = 'none'; }
+
+  async function saveEdit() {
+    const postId = document.getElementById('editPostId').value;
+    const message = document.getElementById('editMessage').value;
+    const imageUrl = document.getElementById('editImageUrl').value;
+    const videoUrl = document.getElementById('editVideoUrl').value;
+    try {
+      const res = await fetch('/edit/' + postId, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body: new URLSearchParams({ message, image_url: imageUrl, video_url: videoUrl }),
+      });
+      if (res.ok) {
+        closeEditModal();
+        htmx.ajax('GET', '/', { target: '#content', swap: 'outerHTML' });
+      }
+    } catch (e) {}
+  }
+
+  // ── Keyboard shortcuts ─────────────────────────
+  document.addEventListener('keydown', (e) => {
+    if (e.target.tagName === 'INPUT' || e.target.tagName === 'TEXTAREA' || e.target.tagName === 'SELECT') {
+      if (e.key === 'Escape') { e.target.blur(); return; }
+      if ((e.metaKey || e.ctrlKey) && e.key === 'Enter') {
+        const form = e.target.closest('form');
+        if (form) { e.preventDefault(); form.requestSubmit(); }
+        return;
+      }
+      return;
+    }
+    if (e.key === 'Escape') {
+      if (document.getElementById('editModal').style.display !== 'none') { closeEditModal(); return; }
+      if (document.getElementById('confirmModal').style.display !== 'none') { closeModal(); return; }
+      if (typeof toggleCompose === 'function') {
+        const s = document.getElementById('composeSection');
+        if (s && s.style.display !== 'none') { toggleCompose(); return; }
+      }
+    }
+    if ((e.metaKey || e.ctrlKey) && e.key === 'n') {
+      if (typeof toggleCompose === 'function') { e.preventDefault(); toggleCompose(); }
+    }
+    if ((e.metaKey || e.ctrlKey) && e.key === 'k') {
+      e.preventDefault();
+      const search = document.getElementById('searchInput');
+      if (search) search.focus();
+    }
+  });
+</script>
+
 {% block scripts %}{% endblock %}
 
 </body>

--- a/dashboard/templates/_columns.html
+++ b/dashboard/templates/_columns.html
@@ -64,10 +64,7 @@
         posts ready to publish
       </div>
       <button class="btn btn-primary btn-sm"
-              hx-post="/approve-all"
-              hx-target="#content"
-              hx-swap="outerHTML"
-              hx-confirm="Publish all {{ total_pending }} pending posts? This is the real thing.">
+              onclick="showConfirm('Publish all', 'Publish all {{ total_pending }} pending posts? This is the real thing.', () => htmx.ajax('POST', '/approve-all', {target:'#content', swap:'outerHTML'}))">
         <svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M22 11.08V12a10 10 0 11-5.93-9.14" stroke-linecap="round" stroke-linejoin="round"/><polyline points="22 4 12 14.01 9 11.01" stroke-linecap="round" stroke-linejoin="round"/></svg>
         Approve all
       </button>
@@ -101,18 +98,13 @@
           <div class="post-actions">
             <button class="btn btn-success btn-sm"
                     data-tip="Approve & publish to all {{ grp|length }} platforms"
-                    hx-post="/approve-group/{{ first.group_id }}"
-                    hx-target="#content"
-                    hx-swap="outerHTML"
-                    hx-confirm="Publish to all {{ grp|length }} platforms? Going live now.">
+                    onclick="showConfirm('Publish broadcast', 'Publish to all {{ grp|length }} platforms? Going live now.', () => htmx.ajax('POST', '/approve-group/{{ first.group_id }}', {target:'#content', swap:'outerHTML'}))">
               <svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><polyline points="20 6 9 17 4 12" stroke-linecap="round" stroke-linejoin="round"/></svg>
               Publish all
             </button>
             <button class="btn btn-ghost btn-sm"
                     data-tip="Reject all in this broadcast"
-                    hx-post="/reject-group/{{ first.group_id }}"
-                    hx-target="#content"
-                    hx-swap="outerHTML">
+                    onclick="showConfirm('Reject broadcast', 'Reject all {{ grp|length }} posts in this broadcast?', () => htmx.ajax('POST', '/reject-group/{{ first.group_id }}', {target:'#content', swap:'outerHTML'}))">
               Reject all
             </button>
           </div>
@@ -126,6 +118,9 @@
             <span class="post-status-dot s-pending"></span>
             <span class="post-status-label">Pending</span>
           </div>
+          {% if p.image_url %}
+            <img class="post-thumb" src="{{ p.image_url }}" alt="" loading="lazy">
+          {% endif %}
           <div class="post-message">{{ p.message }}</div>
           <div class="post-meta">
             {% set cls = {'facebook':'fb','instagram':'ig','whatsapp':'wa','threads':'th','linkedin':'li','tiktok':'tt','youtube':'yt','x':'x'}.get(p.platform, 'fb') %}
@@ -136,20 +131,21 @@
             <span data-tip="{{ p.created_at }}" data-tip-place="bottom">{{ p.created_at | time_ago }}</span>
           </div>
           <div class="post-actions">
+            <button class="btn btn-ghost btn-sm"
+                    data-tip="Edit this post"
+                    onclick="openEditModal({{ p.id }}, {{ p.message | tojson }}, {{ (p.image_url or '') | tojson }}, {{ (p.video_url or '') | tojson }})">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M4 20h4L18.5 9.5a2.1 2.1 0 00-3-3L5 17v3" stroke-linecap="round" stroke-linejoin="round"/></svg>
+              Edit
+            </button>
             <button class="btn btn-success btn-sm"
                     data-tip="Approve & publish to {{ p.account_name }}"
-                    hx-post="/approve/{{ p.id }}"
-                    hx-target="#content"
-                    hx-swap="outerHTML"
-                    hx-confirm="Publish this post to {{ p.account_name }}? Going live now.">
+                    onclick="showConfirm('Publish post', 'Publish this post to {{ p.account_name }}? Going live now.', () => htmx.ajax('POST', '/approve/{{ p.id }}', {target:'#content', swap:'outerHTML'}))">
               <svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><polyline points="20 6 9 17 4 12" stroke-linecap="round" stroke-linejoin="round"/></svg>
               Publish
             </button>
             <button class="btn btn-ghost btn-sm"
                     data-tip="Reject — does not publish"
-                    hx-post="/reject/{{ p.id }}"
-                    hx-target="#content"
-                    hx-swap="outerHTML">
+                    onclick="showConfirm('Reject post', 'Reject this post? It will not be published.', () => htmx.ajax('POST', '/reject/{{ p.id }}', {target:'#content', swap:'outerHTML'}))">
               Reject
             </button>
           </div>
@@ -176,6 +172,9 @@
               <span class="post-status-dot s-success"></span>
               <span class="post-status-label">Live</span>
             </div>
+            {% if p.image_url %}
+              <img class="post-thumb" src="{{ p.image_url }}" alt="" loading="lazy">
+            {% endif %}
             <div class="post-message">{{ p.message }}</div>
             <div class="post-meta">
               {% if p.permalink_url %}

--- a/dashboard/templates/index.html
+++ b/dashboard/templates/index.html
@@ -14,6 +14,26 @@
     </button>
   </div>
 
+  <!-- Search bar -->
+  <div class="search-bar">
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><circle cx="11" cy="11" r="8"/><path d="M21 21l-4.35-4.35" stroke-linecap="round" stroke-linejoin="round"/></svg>
+    <input type="search" id="searchInput" placeholder="Search posts..."
+           hx-get="/search" hx-trigger="input changed delay:300ms"
+           hx-target="#content" hx-swap="outerHTML"
+           name="q" autocomplete="off">
+    <select name="status" id="searchStatus"
+            hx-get="/search" hx-trigger="change"
+            hx-include="#searchInput"
+            hx-target="#content" hx-swap="outerHTML">
+      <option value="">All statuses</option>
+      <option value="pending">Pending</option>
+      <option value="published">Published</option>
+      <option value="scheduled">Scheduled</option>
+      <option value="failed">Failed</option>
+    </select>
+    <span class="search-kbd"><kbd>⌘K</kbd></span>
+  </div>
+
   <!-- Stats strip — compact single row -->
   <div class="stats-strip">
     <div class="strip-stat">
@@ -51,7 +71,7 @@
 
     {# ─── BROADCAST FORM ─────────────────────────────────── #}
     <form id="broadcastForm" class="compose-form" hx-post="/compose" hx-target="#content" hx-swap="outerHTML"
-          hx-on:htmx:after-request="if(event.detail.successful){this.reset();document.getElementById('bccCount').textContent='0';document.getElementById('bImgRow').style.display='none';toggleCompose()}">
+          hx-on:htmx:after-request="if(event.detail.successful){this.reset();updateCharCounter();document.getElementById('bImgRow').style.display='none';toggleCompose()}">
       <div class="compose-platforms">
         <div class="compose-platforms-label">Publish to</div>
         <div class="compose-platforms-groups">
@@ -108,8 +128,7 @@
       <div class="compose-body">
         <textarea id="bMsg" name="message"
                   placeholder="What's on your mind? Drafts go to the approval queue."
-                  oninput="document.getElementById('bccCount').textContent=this.value.length"
-                  required></textarea>
+                  oninput="updateCharCounter()"></textarea>
         <div id="bAiRow" class="img-row ai-row" style="display:none;">
           <span class="img-label">AI prompt</span>
           <input type="text" id="bAiTopic" placeholder="What is this post about?" class="img-input"
@@ -119,7 +138,9 @@
         </div>
         <div id="bImgRow" class="img-row" style="display:none;">
           <span class="img-label">Image URL</span>
-          <input type="url" name="image_url" id="bImg" placeholder="https://example.com/image.jpg" class="img-input">
+          <input type="url" name="image_url" id="bImg" placeholder="https://example.com/image.jpg" class="img-input"
+                 oninput="previewMedia('bImg','bImgPreview')">
+          <img id="bImgPreview" class="media-preview" style="display:none;" alt="Preview">
           <span class="img-hint">Required for Instagram</span>
         </div>
         <div id="bVideoUrlRow" class="img-row" style="display:none;">
@@ -198,33 +219,62 @@
       </div>
       <div class="compose-footer">
         <div class="compose-toolbar">
-          <button type="button" data-tip="Generate with AI" onclick="toggleBroadcastAi()">
+          <button type="button" class="toolbar-btn" onclick="toggleBroadcastAi()">
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M12 3l1.5 4.5L18 9l-4.5 1.5L12 15l-1.5-4.5L6 9l4.5-1.5L12 3z" stroke-linecap="round" stroke-linejoin="round"/><path d="M19 14l.7 2.3L22 17l-2.3.7L19 20l-.7-2.3L16 17l2.3-.7L19 14z" stroke-linecap="round" stroke-linejoin="round"/></svg>
+            <span class="toolbar-label">AI draft</span>
           </button>
-          <button type="button" data-tip="Enhance / rewrite" onclick="toggleRow('bEnhanceRow')">
+          <button type="button" class="toolbar-btn" onclick="toggleRow('bEnhanceRow')">
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M4 20h4L18.5 9.5a2.1 2.1 0 00-3-3L5 17v3" stroke-linecap="round" stroke-linejoin="round"/><path d="M13.5 6.5l3 3"/></svg>
+            <span class="toolbar-label">Enhance</span>
           </button>
-          <button type="button" data-tip="Toggle image" onclick="toggleBroadcastImage()">
+          <button type="button" class="toolbar-btn" onclick="toggleBroadcastImage()">
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><rect x="3" y="3" width="18" height="18" rx="2"/><circle cx="8.5" cy="8.5" r="1.5"/><path d="M21 15l-5-5L5 21"/></svg>
+            <span class="toolbar-label">Image</span>
           </button>
-          <button type="button" data-tip="Generate image with AI" onclick="toggleImageGen()">
+          <button type="button" class="toolbar-btn" onclick="toggleImageGen()">
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><rect x="3" y="3" width="18" height="18" rx="2"/><circle cx="8.5" cy="8.5" r="1.5"/><path d="M21 15l-5-5L5 21"/><path d="M12 3l1.5 4.5L18 9l-4.5 1.5L12 15l-1.5-4.5L6 9l4.5-1.5L12 3z" stroke-linecap="round" stroke-linejoin="round" opacity="0.6"/></svg>
+            <span class="toolbar-label">AI image</span>
           </button>
-          <button type="button" data-tip="Voiceover (ElevenLabs)" onclick="toggleRow('bTtsRow')">
+          <button type="button" class="toolbar-btn" onclick="toggleRow('bTtsRow')">
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M12 1a3 3 0 00-3 3v8a3 3 0 006 0V4a3 3 0 00-3-3z"/><path d="M19 10v2a7 7 0 01-14 0v-2"/><line x1="12" y1="19" x2="12" y2="23"/><line x1="8" y1="23" x2="16" y2="23"/></svg>
+            <span class="toolbar-label">Voice</span>
           </button>
-          <button type="button" data-tip="Captions (Deepgram)" onclick="toggleRow('bCaptionRow')">
+          <button type="button" class="toolbar-btn" onclick="toggleRow('bCaptionRow')">
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><rect x="2" y="15" width="20" height="6" rx="1"/><path d="M6 18h2M10 18h4"/></svg>
+            <span class="toolbar-label">Captions</span>
           </button>
-          <button type="button" data-tip="AI video (Replicate)" onclick="toggleRow('bVideoRow')">
+          <button type="button" class="toolbar-btn" onclick="toggleRow('bVideoRow')">
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><polygon points="5,3 19,12 5,21"/></svg>
+            <span class="toolbar-label">AI video</span>
           </button>
-          <button type="button" data-tip="Sync to Notion" onclick="toggleRow('bNotionRow')">
+          <button type="button" class="toolbar-btn" onclick="toggleRow('bNotionRow')">
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M4 4h16v16H4z" stroke-linecap="round" stroke-linejoin="round"/><path d="M9 4v16M15 4v16" opacity="0.4"/></svg>
+            <span class="toolbar-label">Notion</span>
           </button>
         </div>
         <div class="compose-submit">
-          <span class="char-count"><span id="bccCount">0</span></span>
+          <div class="char-counter" id="charCounter">
+            <span class="char-pill" data-platform="facebook" data-limit="63206">
+              <span class="char-pill-icon fb">f</span>
+              <span class="char-pill-count">0</span>/<span class="char-pill-max">63206</span>
+            </span>
+            <span class="char-pill" data-platform="instagram" data-limit="2200">
+              <span class="char-pill-icon ig">IG</span>
+              <span class="char-pill-count">0</span>/<span class="char-pill-max">2200</span>
+            </span>
+            <span class="char-pill" data-platform="threads" data-limit="500">
+              <span class="char-pill-icon th">@</span>
+              <span class="char-pill-count">0</span>/<span class="char-pill-max">500</span>
+            </span>
+            <span class="char-pill" data-platform="linkedin" data-limit="3000">
+              <span class="char-pill-icon li">in</span>
+              <span class="char-pill-count">0</span>/<span class="char-pill-max">3000</span>
+            </span>
+            <span class="char-pill" data-platform="tiktok" data-limit="2200">
+              <span class="char-pill-icon tt">TT</span>
+              <span class="char-pill-count">0</span>/<span class="char-pill-max">2200</span>
+            </span>
+          </div>
           <button type="submit" class="btn btn-primary btn-sm">
             <svg class="htmx-indicator" viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M21 12a9 9 0 11-6.219-8.56" stroke-linecap="round"/></svg>
             Add to queue
@@ -520,6 +570,74 @@
     } catch (err) { status.textContent = 'Network error.'; }
     finally { btn.disabled = false; }
   }
+
+  // ── Inline media preview ────────────────────────
+  function previewMedia(inputId, previewId) {
+    const input = document.getElementById(inputId);
+    const preview = document.getElementById(previewId);
+    if (!input || !preview) return;
+    const url = input.value.trim();
+    if (url && /^https?:\/\/.+\.(jpg|jpeg|png|gif|webp|svg)(\?.*)?$/i.test(url)) {
+      preview.src = url;
+      preview.style.display = '';
+      preview.onerror = () => { preview.style.display = 'none'; };
+    } else {
+      preview.style.display = 'none';
+    }
+  }
+
+  // ── Character counter ──────────────────────────
+  function updateCharCounter() {
+    const ta = document.getElementById('bMsg');
+    const len = ta ? ta.value.length : 0;
+    const checked = Array.from(
+      document.querySelectorAll('#broadcastForm input[name="platforms"]:checked')
+    ).map(cb => cb.value);
+    document.querySelectorAll('#charCounter .char-pill').forEach(pill => {
+      const plat = pill.dataset.platform;
+      const limit = parseInt(pill.dataset.limit, 10);
+      const countEl = pill.querySelector('.char-pill-count');
+      if (countEl) countEl.textContent = len;
+      pill.style.display = checked.includes(plat) ? '' : 'none';
+      pill.classList.remove('warn', 'over');
+      if (len > limit) pill.classList.add('over');
+      else if (len > limit * 0.9) pill.classList.add('warn');
+    });
+  }
+
+  // Show/hide char pills when platform checkboxes change
+  document.querySelectorAll('#broadcastForm input[name="platforms"]').forEach(cb => {
+    cb.addEventListener('change', updateCharCounter);
+  });
+  // Initialise on load
+  updateCharCounter();
+
+  // ── Draft auto-save ───────────────────────────────
+  const DRAFT_KEY = 'sae_draft_broadcast';
+  function saveDraft() {
+    const ta = document.getElementById('bMsg');
+    if (!ta) return;
+    const val = ta.value.trim();
+    if (val) localStorage.setItem(DRAFT_KEY, val);
+    else localStorage.removeItem(DRAFT_KEY);
+  }
+  function restoreDraft() {
+    const ta = document.getElementById('bMsg');
+    if (!ta) return;
+    const saved = localStorage.getItem(DRAFT_KEY);
+    if (saved && !ta.value.trim()) {
+      ta.value = saved;
+      updateCharCounter();
+    }
+  }
+  restoreDraft();
+  document.getElementById('bMsg')?.addEventListener('input', () => {
+    saveDraft();
+  });
+  // Clear draft on successful submit
+  document.getElementById('broadcastForm')?.addEventListener('htmx:afterRequest', (e) => {
+    if (e.detail.successful) localStorage.removeItem(DRAFT_KEY);
+  });
 
   async function syncToNotion() {
     const body = document.getElementById('bMsg').value.trim();

--- a/dashboard/templates/published.html
+++ b/dashboard/templates/published.html
@@ -17,16 +17,13 @@
       <div class="post-row">
         <div class="post-status">
           <span class="post-status-dot s-success"></span>
-          {% if p.platform == 'instagram' %}
-            <span class="platform-icon ig" style="width:14px;height:14px;font-size:7px;">IG</span>
-          {% elif p.platform == 'whatsapp' %}
-            <span class="platform-icon wa" style="width:14px;height:14px;font-size:8px;">W</span>
-          {% elif p.platform == 'threads' %}
-            <span class="platform-icon th" style="width:14px;height:14px;font-size:8px;">@</span>
-          {% else %}
-            <span class="platform-icon fb" style="width:14px;height:14px;font-size:8px;">f</span>
-          {% endif %}
+          {% set cls = {'facebook':'fb','instagram':'ig','whatsapp':'wa','threads':'th','linkedin':'li','tiktok':'tt','youtube':'yt','x':'x'}.get(p.platform, 'fb') %}
+          {% set icon = {'facebook':'f','instagram':'IG','whatsapp':'W','threads':'@','linkedin':'in','tiktok':'TT','youtube':'YT','x':'\U0001d54f'}.get(p.platform, 'f') %}
+          <span class="platform-icon {{ cls }}" style="width:14px;height:14px;font-size:8px;">{{ icon }}</span>
         </div>
+        {% if p.image_url %}
+          <img class="post-thumb" src="{{ p.image_url }}" alt="" loading="lazy">
+        {% endif %}
         <div class="post-message">{{ p.message }}</div>
         <div class="post-meta">
           <span>{{ p.account_name }}</span>


### PR DESCRIPTION
## Summary
- Add full light/dark theme toggle with CSS custom properties and localStorage persistence
- Replace browser `hx-confirm` dialogs with styled confirmation modals across all actions
- Add edit modal for pending posts (message, image URL, video URL)
- Add HTMX live search with debounced text input and status filter dropdown
- Add per-platform character counter pills on compose form (only shows checked platforms)
- Add draft auto-save to localStorage with restore on page load
- Add inline image preview when entering image URLs in compose
- Add post thumbnails in approval queue and published list for posts with images
- Add keyboard shortcuts: Ctrl+N compose, Ctrl+K search, Ctrl+Enter submit, Escape close
- Add labelled toolbar buttons replacing icon-only buttons
- Add `/edit/{post_id}` and `/search` backend endpoints with `db.search_posts()`
- Fix published page to use dynamic platform icon lookup (supports all platforms)

## Test plan
- [ ] Open dashboard, verify dark theme renders correctly
- [ ] Toggle to light theme, verify all elements adapt
- [ ] Compose a post, check character counter pills appear for checked platforms
- [ ] Type past 90% of a platform limit, verify warn state (yellow border)
- [ ] Use live search bar to filter posts by text and status
- [ ] Click Edit on a pending post, modify message, save
- [ ] Click Approve on a pending post, verify modal confirmation appears
- [ ] Press Ctrl+N to toggle compose, Ctrl+K to focus search, Escape to close
- [ ] Reload page, verify draft text is restored from localStorage
- [ ] Enter an image URL in compose, verify inline preview thumbnail

🤖 Generated with [Claude Code](https://claude.com/claude-code)